### PR TITLE
add mcs serviceexports and serviceimports

### DIFF
--- a/multicluster/config/crd/bases/multicluster.x-k8s.io_serviceexports.yaml
+++ b/multicluster/config/crd/bases/multicluster.x-k8s.io_serviceexports.yaml
@@ -1,0 +1,120 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  scope: Namespaced
+  names:
+    plural: serviceexports
+    singular: serviceexport
+    kind: ServiceExport
+    shortNames:
+    - svcex
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    "schema":
+      "openAPIV3Schema":
+        description: ServiceExport declares that the Service with the same name and
+          namespace as this export should be consumable from other clusters.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: status describes the current state of an exported service.
+              Service configuration comes from the Service that had the same name
+              and namespace as this ServiceExport. Populated by the multi-cluster
+              service implementation's controller.
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  type: object
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      type: string
+                      format: date-time
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                      maxLength: 32768
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      type: integer
+                      format: int64
+                      minimum: 0
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map

--- a/multicluster/config/crd/bases/multicluster.x-k8s.io_serviceimports.yaml
+++ b/multicluster/config/crd/bases/multicluster.x-k8s.io_serviceimports.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceimports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  scope: Namespaced
+  names:
+    plural: serviceimports
+    singular: serviceimport
+    kind: ServiceImport
+    shortNames:
+    - svcim
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The type of this ServiceImport
+      jsonPath: .spec.type
+    - name: IP
+      type: string
+      description: The VIP for this ServiceImport
+      jsonPath: .spec.ips
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    "schema":
+      "openAPIV3Schema":
+        description: ServiceImport describes a service imported from clusters in a
+          ClusterSet.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the behavior of a ServiceImport.
+            type: object
+            required:
+            - ports
+            - type
+            properties:
+              ips:
+                description: ip will be used as the VIP for this service when type
+                  is ClusterSetIP.
+                type: array
+                maxItems: 1
+                items:
+                  type: string
+              ports:
+                type: array
+                items:
+                  description: ServicePort represents the port on which the service
+                    is exposed
+                  type: object
+                  required:
+                  - port
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and http://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                        Field can be enabled with ServiceAppProtocol feature gate.
+                      type: string
+                    name:
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort. Optional
+                        if only one ServicePort is defined on this service.
+                      type: string
+                    port:
+                      description: The port that will be exposed by this service.
+                      type: integer
+                      format: int32
+                    protocol:
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
+                      type: string
+                x-kubernetes-list-type: atomic
+              sessionAffinity:
+                description: 'Supports "ClientIP" and "None". Used to maintain session
+                  affinity. Enable client IP based session affinity. Must be ClientIP
+                  or None. Defaults to None. Ignored when type is Headless More info:
+                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                type: string
+              sessionAffinityConfig:
+                description: sessionAffinityConfig contains session affinity configuration.
+                type: object
+                properties:
+                  clientIP:
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
+                    type: object
+                    properties:
+                      timeoutSeconds:
+                        description: timeoutSeconds specifies the seconds of ClientIP
+                          type session sticky time. The value must be >0 && <=86400(for
+                          1 day) if ServiceAffinity == "ClientIP". Default value is
+                          10800(for 3 hours).
+                        type: integer
+                        format: int32
+              type:
+                description: type defines the type of this service. Must be ClusterSetIP
+                  or Headless.
+                type: string
+                enum:
+                - ClusterSetIP
+                - Headless
+          status:
+            description: status contains information about the exported services that
+              form the multi-cluster service referenced by this ServiceImport.
+            type: object
+            properties:
+              clusters:
+                description: clusters is the list of exporting clusters from which
+                  this service was derived.
+                type: array
+                items:
+                  description: ClusterStatus contains service configuration mapped
+                    to a specific source cluster
+                  type: object
+                  required:
+                  - cluster
+                  properties:
+                    cluster:
+                      description: cluster is the name of the exporting cluster. Must
+                        be a valid RFC-1123 DNS label.
+                      type: string
+                x-kubernetes-list-map-keys:
+                - cluster
+                x-kubernetes-list-type: map

--- a/multicluster/config/crd/kustomization.yaml
+++ b/multicluster/config/crd/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - bases/multicluster.crd.antrea.io_resourceimportfilters.yaml
 - bases/multicluster.crd.antrea.io_resourceexports.yaml
 - bases/multicluster.crd.antrea.io_resourceimports.yaml
+- bases/multicluster.x-k8s.io_serviceexports.yaml
+- bases/multicluster.x-k8s.io_serviceimports.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/multicluster/config/multi-cluster.yaml
+++ b/multicluster/config/multi-cluster.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
     controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app: antrea
   name: clusterclaims.multicluster.crd.antrea.io
 spec:
   conversion:
@@ -30,14 +32,10 @@ spec:
         description: ClusterClaim is the Schema for the clusterclaims API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -63,6 +61,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
     controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app: antrea
   name: clustersets.multicluster.crd.antrea.io
 spec:
   conversion:
@@ -86,17 +86,13 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterSet is the Schema for the clustersets API
+        description: ClusterSet is the Schema for the clustersets API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -112,21 +108,18 @@ spec:
                       description: Identify member cluster in ClusterSet.
                       type: string
                     secret:
-                      description: Secret name to access API server of the member
-                        from the leader cluster.
+                      description: Secret name to access API server of the member from the leader cluster.
                       type: string
                     server:
                       description: API server of the destination cluster.
                       type: string
                     serviceAccount:
-                      description: ServiceAccount used by the member cluster to access
-                        into leader cluster.
+                      description: ServiceAccount used by the member cluster to access into leader cluster.
                       type: string
                   type: object
                 type: array
               members:
-                description: Members include member clusters known to the leader clusters.
-                  Used in leader cluster.
+                description: Members include member clusters known to the leader clusters. Used in leader cluster.
                 items:
                   description: MemberCluster defines member cluster information.
                   properties:
@@ -134,21 +127,18 @@ spec:
                       description: Identify member cluster in ClusterSet.
                       type: string
                     secret:
-                      description: Secret name to access API server of the member
-                        from the leader cluster.
+                      description: Secret name to access API server of the member from the leader cluster.
                       type: string
                     server:
                       description: API server of the destination cluster.
                       type: string
                     serviceAccount:
-                      description: ServiceAccount used by the member cluster to access
-                        into leader cluster.
+                      description: ServiceAccount used by the member cluster to access into leader cluster.
                       type: string
                   type: object
                 type: array
               namespace:
-                description: Namespace to connect to in leader clusters. Used in member
-                  cluster.
+                description: Namespace to connect to in leader clusters. Used in member cluster.
                 type: string
             type: object
           status:
@@ -163,25 +153,20 @@ spec:
                       type: string
                     conditions:
                       items:
-                        description: ClusterCondition indicates the readiness condition
-                          of a cluster.
+                        description: ClusterCondition indicates the readiness condition of a cluster.
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transited from one
-                              status to another.
+                            description: Last time the condition transited from one status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details
-                              about the transition.
+                            description: A human readable message indicating details about the transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the
-                              condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
+                            description: Status of the condition, one of True, False, Unknown.
                             type: string
                           type:
                             type: string
@@ -192,21 +177,17 @@ spec:
               conditions:
                 description: The overall condition of the cluster set.
                 items:
-                  description: ClusterSetCondition indicates the readiness condition
-                    of the clusterSet.
+                  description: ClusterSetCondition indicates the readiness condition of the clusterSet.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transited from one status
-                        to another.
+                      description: Last time the condition transited from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
+                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's last transition.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -246,6 +227,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
     controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app: antrea
   name: memberclusterannounces.multicluster.crd.antrea.io
 spec:
   conversion:
@@ -269,13 +252,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MemberClusterAnnounce is the Schema for the memberclusterannounces
-          API
+        description: MemberClusterAnnounce is the Schema for the memberclusterannounces API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           clusterID:
             description: ClusterID of the member cluster.
@@ -284,9 +264,7 @@ spec:
             description: ClusterSet this member belongs to.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           leaderClusterID:
             description: Leader cluster this member has selected.
@@ -309,6 +287,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
+  labels:
+    app: antrea
   name: resourceexportfilters.multicluster.crd.antrea.io
 spec:
   group: multicluster.crd.antrea.io
@@ -322,18 +302,13 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceExportFilter is the Schema for the ResourceExportFilters
-          API
+        description: ResourceExportFilter is the Schema for the ResourceExportFilters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -341,8 +316,7 @@ spec:
             description: ResourceExportFilterSpec defines the desired state of ResourceExportFilter
             type: object
           status:
-            description: ResourceExportFilterStatus defines the observed state of
-              ResourceExportFilter
+            description: ResourceExportFilterStatus defines the observed state of ResourceExportFilter
             type: object
         type: object
     served: true
@@ -362,6 +336,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
     controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app: antrea
   name: resourceexports.multicluster.crd.antrea.io
 spec:
   conversion:
@@ -385,64 +361,42 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceExport is the Schema for the resourceexports API
+        description: ResourceExport is the Schema for the resourceexports API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ResourceExportSpec defines the desired state of ResourceExport
+            description: ResourceExportSpec defines the desired state of ResourceExport.
             properties:
               clusterID:
-                description: ClusterID specifies the member cluster this resource
-                  exported from.
+                description: ClusterID specifies the member cluster this resource exported from.
                 type: string
               endpoints:
                 description: If exported resource is EndPoints.
                 properties:
                   subsets:
                     items:
-                      description: 'EndpointSubset is a group of addresses with a
-                        common set of ports. The expanded set of endpoints is the
-                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
-                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
-                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
-                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
-                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
                       properties:
                         addresses:
-                          description: IP addresses which offer the related ports
-                            that are marked as ready. These endpoints should be considered
-                            safe for load balancers and clients to utilize.
+                          description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
                           items:
-                            description: EndpointAddress is a tuple that describes
-                              single IP address.
+                            description: EndpointAddress is a tuple that describes single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be
-                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
-                                  or link-local multicast ((224.0.0.0/24). IPv6 is
-                                  also accepted but not fully supported on all platforms.
-                                  Also, certain kubernetes components, like kube-proxy,
-                                  are not IPv6 ready. TODO: This should allow hostname
-                                  or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint.
-                                  This can be used to determine endpoints local to
-                                  a node.'
+                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -451,41 +405,22 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object
-                                      instead of an entire object, this string should
-                                      contain a valid JSON/Go field access statement,
-                                      such as desiredState.manifest.containers[2].
-                                      For example, if the object reference is to a
-                                      container within a pod, this would take on a
-                                      value like: "spec.containers{name}" (where "name"
-                                      refers to the name of the container that triggered
-                                      the event) or if no container name is specified
-                                      "spec.containers[2]" (container with index 2
-                                      in this pod). This syntax is chosen only to
-                                      have some well-defined way of referencing a
-                                      part of an object. TODO: this design is not
-                                      final and this field is subject to change in
-                                      the future.'
+                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info:
-                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More
-                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which
-                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -493,30 +428,18 @@ spec:
                             type: object
                           type: array
                         notReadyAddresses:
-                          description: IP addresses which offer the related ports
-                            but are not currently marked as ready because they have
-                            not yet finished starting, have recently failed a readiness
-                            check, or have recently failed a liveness check.
+                          description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
                           items:
-                            description: EndpointAddress is a tuple that describes
-                              single IP address.
+                            description: EndpointAddress is a tuple that describes single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be
-                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
-                                  or link-local multicast ((224.0.0.0/24). IPv6 is
-                                  also accepted but not fully supported on all platforms.
-                                  Also, certain kubernetes components, like kube-proxy,
-                                  are not IPv6 ready. TODO: This should allow hostname
-                                  or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint.
-                                  This can be used to determine endpoints local to
-                                  a node.'
+                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -525,41 +448,22 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object
-                                      instead of an entire object, this string should
-                                      contain a valid JSON/Go field access statement,
-                                      such as desiredState.manifest.containers[2].
-                                      For example, if the object reference is to a
-                                      container within a pod, this would take on a
-                                      value like: "spec.containers{name}" (where "name"
-                                      refers to the name of the container that triggered
-                                      the event) or if no container name is specified
-                                      "spec.containers[2]" (container with index 2
-                                      in this pod). This syntax is chosen only to
-                                      have some well-defined way of referencing a
-                                      part of an object. TODO: this design is not
-                                      final and this field is subject to change in
-                                      the future.'
+                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info:
-                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More
-                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which
-                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -569,24 +473,13 @@ spec:
                         ports:
                           description: Port numbers available on the related IP addresses.
                           items:
-                            description: EndpointPort is a tuple that describes a
-                              single port.
+                            description: EndpointPort is a tuple that describes a single port.
                             properties:
                               appProtocol:
-                                description: The application protocol for this port.
-                                  This field follows standard Kubernetes label syntax.
-                                  Un-prefixed names are reserved for IANA standard
-                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
-                                  Non-standard protocols should use prefixed names
-                                  such as mycompany.com/my-custom-protocol. This is
-                                  a beta field that is guarded by the ServiceAppProtocol
-                                  feature gate and enabled by default.
+                                description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
                                 type: string
                               name:
-                                description: The name of this port.  This must match
-                                  the 'name' field in the corresponding ServicePort.
-                                  Must be a DNS_LABEL. Optional only if one port is
-                                  defined.
+                                description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
                                 type: string
                               port:
                                 description: The port number of the endpoint.
@@ -594,8 +487,7 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: The IP protocol for this port. Must be
-                                  UDP, TCP, or SCTP. Default is TCP.
+                                description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
                                 type: string
                             required:
                             - port
@@ -608,35 +500,28 @@ spec:
                 description: If exported resource is ExternalEntity.
                 properties:
                   externalentityspec:
-                    description: ExternalEntitySpec defines the desired state for
-                      ExternalEntity.
+                    description: ExternalEntitySpec defines the desired state for ExternalEntity.
                     properties:
                       endpoints:
-                        description: Endpoints is a list of external endpoints associated
-                          with this entity.
+                        description: Endpoints is a list of external endpoints associated with this entity.
                         items:
-                          description: Endpoint refers to an endpoint associated with
-                            the ExternalEntity.
+                          description: Endpoint refers to an endpoint associated with the ExternalEntity.
                           properties:
                             ip:
                               description: IP associated with this endpoint.
                               type: string
                             name:
-                              description: Name identifies this endpoint. Could be
-                                the network interface name in case of VMs.
+                              description: Name identifies this endpoint. Could be the network interface name in case of VMs.
                               type: string
                           type: object
                         type: array
                       externalNode:
-                        description: ExternalNode is the opaque identifier of the
-                          agent/controller responsible for additional processing or
-                          handling of this external entity.
+                        description: ExternalNode is the opaque identifier of the agent/controller responsible for additional processing or handling of this external entity.
                         type: string
                       ports:
                         description: Ports maintain the list of named ports.
                         items:
-                          description: NamedPort describes the port and protocol to
-                            match in a rule.
+                          description: NamedPort describes the port and protocol to match in a rule.
                           properties:
                             name:
                               description: Name associated with the Port.
@@ -647,9 +532,7 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The protocol (TCP, UDP, or SCTP) which
-                                traffic must match. If not specified, this field defaults
-                                to TCP.
+                              description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
                               type: string
                           type: object
                         type: array
@@ -675,231 +558,72 @@ spec:
                 description: If exported resource is Service.
                 properties:
                   serviceSpec:
-                    description: ServiceSpec describes the attributes that a user
-                      creates on a service.
+                    description: ServiceSpec describes the attributes that a user creates on a service.
                     properties:
                       allocateLoadBalancerNodePorts:
-                        description: allocateLoadBalancerNodePorts defines if NodePorts
-                          will be automatically allocated for services with type LoadBalancer.  Default
-                          is "true". It may be set to "false" if the cluster load-balancer
-                          does not rely on NodePorts. allocateLoadBalancerNodePorts
-                          may only be set for services with type LoadBalancer and
-                          will be cleared if the type is changed to any other type.
-                          This field is alpha-level and is only honored by servers
-                          that enable the ServiceLBNodePortControl feature.
+                        description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
                         type: boolean
                       clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly. If an address is specified
-                          manually, is in-range (as per system configuration), and
-                          is not in use, it will be allocated to the service; otherwise
-                          creation of the service will fail. This field may not be
-                          changed through updates unless the type field is also being
-                          changed to ExternalName (which requires this field to be
-                          blank) or the type field is being changed from ExternalName
-                          (in which case this field may optionally be specified, as
-                          describe above).  Valid values are "None", empty string
-                          (""), or a valid IP address. Setting this to "None" makes
-                          a "headless service" (no virtual IP), which is useful when
-                          direct endpoint connections are preferred and proxying is
-                          not required.  Only applies to types ClusterIP, NodePort,
-                          and LoadBalancer. If this field is specified when creating
-                          a Service of type ExternalName, creation will fail. This
-                          field will be wiped when updating a Service to type ExternalName.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       clusterIPs:
-                        description: "ClusterIPs is a list of IP addresses assigned
-                          to this service, and are usually assigned randomly.  If
-                          an address is specified manually, is in-range (as per system
-                          configuration), and is not in use, it will be allocated
-                          to the service; otherwise creation of the service will fail.
-                          This field may not be changed through updates unless the
-                          type field is also being changed to ExternalName (which
-                          requires this field to be empty) or the type field is being
-                          changed from ExternalName (in which case this field may
-                          optionally be specified, as describe above).  Valid values
-                          are \"None\", empty string (\"\"), or a valid IP address.
-                          \ Setting this to \"None\" makes a \"headless service\"
-                          (no virtual IP), which is useful when direct endpoint connections
-                          are preferred and proxying is not required.  Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. If this
-                          field is specified when creating a Service of type ExternalName,
-                          creation will fail. This field will be wiped when updating
-                          a Service to type ExternalName.  If this field is not specified,
-                          it will be initialized from the clusterIP field.  If this
-                          field is specified, clients must ensure that clusterIPs[0]
-                          and clusterIP have the same value. \n Unless the \"IPv6DualStack\"
-                          feature gate is enabled, this field is limited to one value,
-                          which must be the same as the clusterIP field.  If the feature
-                          gate is enabled, this field may hold a maximum of two entries
-                          (dual-stack IPs, in either order).  These IPs must correspond
-                          to the values of the ipFamilies field. Both clusterIPs and
-                          ipFamilies are governed by the ipFamilyPolicy field. More
-                          info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                        description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
+                        description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
                         items:
                           type: string
                         type: array
                       externalName:
-                        description: externalName is the external reference that discovery
-                          mechanisms will return as an alias for this service (e.g.
-                          a DNS CNAME record). No proxying will be involved.  Must
-                          be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                          and requires `type` to be "ExternalName".
+                        description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                         type: string
                       externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service
-                          desires to route external traffic to node-local or cluster-wide
-                          endpoints. "Local" preserves the client source IP and avoids
-                          a second hop for LoadBalancer and Nodeport type services,
-                          but risks potentially imbalanced traffic spreading. "Cluster"
-                          obscures the client source IP and may cause a second hop
-                          to another node, but should have good overall load-spreading.
+                        description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
                         type: string
                       healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. This only applies when type is
-                          set to LoadBalancer and externalTrafficPolicy is set to
-                          Local. If a value is specified, is in-range, and is not
-                          in use, it will be used.  If not specified, a value will
-                          be automatically allocated.  External systems (e.g. load-balancers)
-                          can use this port to determine if a given node holds endpoints
-                          for this service or not.  If this field is specified when
-                          creating a Service which does not need it, creation will
-                          fail. This field will be wiped when updating a Service to
-                          no longer need it (e.g. changing type).
+                        description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
                         format: int32
                         type: integer
                       internalTrafficPolicy:
-                        description: InternalTrafficPolicy specifies if the cluster
-                          internal traffic should be routed to all endpoints or node-local
-                          endpoints only. "Cluster" routes internal traffic to a Service
-                          to all endpoints. "Local" routes traffic to node-local endpoints
-                          only, traffic is dropped if no node-local endpoints are
-                          ready. The default value is "Cluster".
+                        description: InternalTrafficPolicy specifies if the cluster internal traffic should be routed to all endpoints or node-local endpoints only. "Cluster" routes internal traffic to a Service to all endpoints. "Local" routes traffic to node-local endpoints only, traffic is dropped if no node-local endpoints are ready. The default value is "Cluster".
                         type: string
                       ipFamilies:
-                        description: "IPFamilies is a list of IP families (e.g. IPv4,
-                          IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
-                          feature gate.  This field is usually assigned automatically
-                          based on cluster configuration and the ipFamilyPolicy field.
-                          If this field is specified manually, the requested family
-                          is available in the cluster, and ipFamilyPolicy allows it,
-                          it will be used; otherwise creation of the service will
-                          fail.  This field is conditionally mutable: it allows for
-                          adding or removing a secondary IP family, but it does not
-                          allow changing the primary IP family of the Service.  Valid
-                          values are \"IPv4\" and \"IPv6\".  This field only applies
-                          to Services of types ClusterIP, NodePort, and LoadBalancer,
-                          and does apply to \"headless\" services.  This field will
-                          be wiped when updating a Service to type ExternalName. \n
-                          This field may hold a maximum of two entries (dual-stack
-                          families, in either order).  These families must correspond
-                          to the values of the clusterIPs field, if specified. Both
-                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy
-                          field."
+                        description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
                         items:
-                          description: IPFamily represents the IP Family (IPv4 or
-                            IPv6). This type is used to express the family of an IP
-                            expressed by a type (e.g. service.spec.ipFamilies).
+                          description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       ipFamilyPolicy:
-                        description: IPFamilyPolicy represents the dual-stack-ness
-                          requested or required by this Service, and is gated by the
-                          "IPv6DualStack" feature gate.  If there is no value provided,
-                          then this field will be set to SingleStack. Services can
-                          be "SingleStack" (a single IP family), "PreferDualStack"
-                          (two IP families on dual-stack configured clusters or a
-                          single IP family on single-stack clusters), or "RequireDualStack"
-                          (two IP families on dual-stack configured clusters, otherwise
-                          fail). The ipFamilies and clusterIPs fields depend on the
-                          value of this field.  This field will be wiped when updating
-                          a service to type ExternalName.
+                        description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
                         type: string
                       loadBalancerClass:
-                        description: loadBalancerClass is the class of the load balancer
-                          implementation this Service belongs to. If specified, the
-                          value of this field must be a label-style identifier, with
-                          an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
-                          Unprefixed names are reserved for end-users. This field
-                          can only be set when the Service type is 'LoadBalancer'.
-                          If not set, the default load balancer implementation is
-                          used, today this is typically done through the cloud provider
-                          integration, but should apply for any default implementation.
-                          If set, it is assumed that a load balancer implementation
-                          is watching for Services with a matching class. Any default
-                          load balancer implementation (e.g. cloud providers) should
-                          ignore Services that set this field. This field can only
-                          be set when creating or updating a Service to type 'LoadBalancer'.
-                          Once set, it can not be changed. This field will be wiped
-                          when a service is updated to a non 'LoadBalancer' type.
+                        description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                         type: string
                       loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
                         type: string
                       loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
                         items:
                           type: string
                         type: array
                       ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         items:
-                          description: ServicePort contains information on service's
-                            port.
+                          description: ServicePort contains information on service's port.
                           properties:
                             appProtocol:
-                              description: The application protocol for this port.
-                                This field follows standard Kubernetes label syntax.
-                                Un-prefixed names are reserved for IANA standard service
-                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
-                                Non-standard protocols should use prefixed names such
-                                as mycompany.com/my-custom-protocol. This is a beta
-                                field that is guarded by the ServiceAppProtocol feature
-                                gate and enabled by default.
+                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
                               type: string
                             name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
                               type: string
                             nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type is NodePort or LoadBalancer.  Usually
-                                assigned by the system. If a value is specified, in-range,
-                                and not in use it will be used, otherwise the operation
-                                will fail.  If not specified, a port will be allocated
-                                if this Service requires one.  If this field is specified
-                                when creating a Service which does not need it, creation
-                                will fail. This field will be wiped when updating
-                                a Service to no longer need it (e.g. changing type
-                                from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
                               format: int32
                               type: integer
                             port:
@@ -908,22 +632,13 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                             targetPort:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                               x-kubernetes-int-or-string: true
                           required:
                           - port
@@ -934,114 +649,58 @@ spec:
                         - protocol
                         x-kubernetes-list-type: map
                       publishNotReadyAddresses:
-                        description: publishNotReadyAddresses indicates that any agent
-                          which deals with endpoints for this Service should disregard
-                          any indications of ready/not-ready. The primary use case
-                          for setting this field is for a StatefulSet's Headless Service
-                          to propagate SRV DNS records for its Pods for the purpose
-                          of peer discovery. The Kubernetes controllers that generate
-                          Endpoints and EndpointSlice resources for Services interpret
-                          this to mean that all endpoints are considered "ready" even
-                          if the Pods themselves are not. Agents which consume only
-                          Kubernetes generated endpoints through the Endpoints or
-                          EndpointSlice resources can safely assume this behavior.
+                        description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
                         type: boolean
                       selector:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                         type: object
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations
-                          of session affinity.
+                        description: sessionAffinityConfig contains the configurations of session affinity.
                         properties:
                           clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
+                            description: clientIP contains the configurations of Client IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       topologyKeys:
-                        description: topologyKeys is a preference-order list of topology
-                          keys which implementations of services should use to preferentially
-                          sort endpoints when accessing this Service, it can not be
-                          used at the same time as externalTrafficPolicy=Local. Topology
-                          keys must be valid label keys and at most 16 keys may be
-                          specified. Endpoints are chosen based on the first topology
-                          key with available backends. If this field is specified
-                          and all entries have no backends that match the topology
-                          of the client, the service has no backends for that client
-                          and connections should fail. The special value "*" may be
-                          used to mean "any topology". This catch-all value, if used,
-                          only makes sense as the last value in the list. If this
-                          is not specified or empty, no topology constraints will
-                          be applied. This field is alpha-level and is only honored
-                          by servers that enable the ServiceTopology feature. This
-                          field is deprecated and will be removed in a future version.
+                        description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature. This field is deprecated and will be removed in a future version.
                         items:
                           type: string
                         type: array
                       type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal
-                          IP address for load-balancing to endpoints. Endpoints are
-                          determined by the selector or if that is not specified,
-                          by manual construction of an Endpoints object or EndpointSlice
-                          objects. If clusterIP is "None", no virtual IP is allocated
-                          and the endpoints are published as a set of endpoints rather
-                          than a virtual IP. "NodePort" builds on ClusterIP and allocates
-                          a port on every node which routes to the same endpoints
-                          as the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the same endpoints as the clusterIP.
-                          "ExternalName" aliases this service to the specified externalName.
-                          Several other fields do not apply to ExternalName services.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
                         type: string
                     type: object
                 type: object
             type: object
           status:
-            description: ResourceExportStatus defines the observed state of ResourceExport
+            description: ResourceExportStatus defines the observed state of ResourceExport.
             properties:
               conditions:
                 items:
-                  description: ResourceExportCondition indicates the readiness condition
-                    of the ResourceExport
+                  description: ResourceExportCondition indicates the readiness condition of the ResourceExport.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transited from one status
-                        to another
+                      description: Last time the condition transited from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition
+                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown
+                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
                       type: string
@@ -1066,6 +725,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
+  labels:
+    app: antrea
   name: resourceimportfilters.multicluster.crd.antrea.io
 spec:
   group: multicluster.crd.antrea.io
@@ -1079,18 +740,13 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceImportFilter is the Schema for the ResourceImportFilters
-          API
+        description: ResourceImportFilter is the Schema for the ResourceImportFilters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1098,8 +754,7 @@ spec:
             description: ResourceImportFilterSpec defines the desired state of ResourceImportFilter
             type: object
           status:
-            description: ResourceImportFilterStatus defines the observed state of
-              ResourceImportFilter
+            description: ResourceImportFilterStatus defines the observed state of ResourceImportFilter
             type: object
         type: object
     served: true
@@ -1119,6 +774,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
     controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app: antrea
   name: resourceimports.multicluster.crd.antrea.io
 spec:
   conversion:
@@ -1142,26 +799,21 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceImport is the Schema for the resourceimports API
+        description: ResourceImport is the Schema for the resourceimports API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ResourceImportSpec defines the desired state of ResourceImport
+            description: ResourceImportSpec defines the desired state of ResourceImport.
             properties:
               clusterID:
-                description: ClusterIDs specifies the member clusters this resource
-                  to import to. When not specified, import to all member clusters.
+                description: ClusterIDs specifies the member clusters this resource to import to. When not specified, import to all member clusters.
                 items:
                   type: string
                 type: array
@@ -1170,38 +822,21 @@ spec:
                 properties:
                   subsets:
                     items:
-                      description: 'EndpointSubset is a group of addresses with a
-                        common set of ports. The expanded set of endpoints is the
-                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
-                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
-                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
-                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
-                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
                       properties:
                         addresses:
-                          description: IP addresses which offer the related ports
-                            that are marked as ready. These endpoints should be considered
-                            safe for load balancers and clients to utilize.
+                          description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
                           items:
-                            description: EndpointAddress is a tuple that describes
-                              single IP address.
+                            description: EndpointAddress is a tuple that describes single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be
-                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
-                                  or link-local multicast ((224.0.0.0/24). IPv6 is
-                                  also accepted but not fully supported on all platforms.
-                                  Also, certain kubernetes components, like kube-proxy,
-                                  are not IPv6 ready. TODO: This should allow hostname
-                                  or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint.
-                                  This can be used to determine endpoints local to
-                                  a node.'
+                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -1210,41 +845,22 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object
-                                      instead of an entire object, this string should
-                                      contain a valid JSON/Go field access statement,
-                                      such as desiredState.manifest.containers[2].
-                                      For example, if the object reference is to a
-                                      container within a pod, this would take on a
-                                      value like: "spec.containers{name}" (where "name"
-                                      refers to the name of the container that triggered
-                                      the event) or if no container name is specified
-                                      "spec.containers[2]" (container with index 2
-                                      in this pod). This syntax is chosen only to
-                                      have some well-defined way of referencing a
-                                      part of an object. TODO: this design is not
-                                      final and this field is subject to change in
-                                      the future.'
+                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info:
-                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More
-                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which
-                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -1252,30 +868,18 @@ spec:
                             type: object
                           type: array
                         notReadyAddresses:
-                          description: IP addresses which offer the related ports
-                            but are not currently marked as ready because they have
-                            not yet finished starting, have recently failed a readiness
-                            check, or have recently failed a liveness check.
+                          description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
                           items:
-                            description: EndpointAddress is a tuple that describes
-                              single IP address.
+                            description: EndpointAddress is a tuple that describes single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be
-                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
-                                  or link-local multicast ((224.0.0.0/24). IPv6 is
-                                  also accepted but not fully supported on all platforms.
-                                  Also, certain kubernetes components, like kube-proxy,
-                                  are not IPv6 ready. TODO: This should allow hostname
-                                  or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint.
-                                  This can be used to determine endpoints local to
-                                  a node.'
+                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -1284,41 +888,22 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object
-                                      instead of an entire object, this string should
-                                      contain a valid JSON/Go field access statement,
-                                      such as desiredState.manifest.containers[2].
-                                      For example, if the object reference is to a
-                                      container within a pod, this would take on a
-                                      value like: "spec.containers{name}" (where "name"
-                                      refers to the name of the container that triggered
-                                      the event) or if no container name is specified
-                                      "spec.containers[2]" (container with index 2
-                                      in this pod). This syntax is chosen only to
-                                      have some well-defined way of referencing a
-                                      part of an object. TODO: this design is not
-                                      final and this field is subject to change in
-                                      the future.'
+                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info:
-                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More
-                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which
-                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -1328,24 +913,13 @@ spec:
                         ports:
                           description: Port numbers available on the related IP addresses.
                           items:
-                            description: EndpointPort is a tuple that describes a
-                              single port.
+                            description: EndpointPort is a tuple that describes a single port.
                             properties:
                               appProtocol:
-                                description: The application protocol for this port.
-                                  This field follows standard Kubernetes label syntax.
-                                  Un-prefixed names are reserved for IANA standard
-                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
-                                  Non-standard protocols should use prefixed names
-                                  such as mycompany.com/my-custom-protocol. This is
-                                  a beta field that is guarded by the ServiceAppProtocol
-                                  feature gate and enabled by default.
+                                description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
                                 type: string
                               name:
-                                description: The name of this port.  This must match
-                                  the 'name' field in the corresponding ServicePort.
-                                  Must be a DNS_LABEL. Optional only if one port is
-                                  defined.
+                                description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
                                 type: string
                               port:
                                 description: The port number of the endpoint.
@@ -1353,8 +927,7 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: The IP protocol for this port. Must be
-                                  UDP, TCP, or SCTP. Default is TCP.
+                                description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
                                 type: string
                             required:
                             - port
@@ -1367,35 +940,28 @@ spec:
                 description: If imported resource is ExternalEntity.
                 properties:
                   externalentityspec:
-                    description: ExternalEntitySpec defines the desired state for
-                      ExternalEntity.
+                    description: ExternalEntitySpec defines the desired state for ExternalEntity.
                     properties:
                       endpoints:
-                        description: Endpoints is a list of external endpoints associated
-                          with this entity.
+                        description: Endpoints is a list of external endpoints associated with this entity.
                         items:
-                          description: Endpoint refers to an endpoint associated with
-                            the ExternalEntity.
+                          description: Endpoint refers to an endpoint associated with the ExternalEntity.
                           properties:
                             ip:
                               description: IP associated with this endpoint.
                               type: string
                             name:
-                              description: Name identifies this endpoint. Could be
-                                the network interface name in case of VMs.
+                              description: Name identifies this endpoint. Could be the network interface name in case of VMs.
                               type: string
                           type: object
                         type: array
                       externalNode:
-                        description: ExternalNode is the opaque identifier of the
-                          agent/controller responsible for additional processing or
-                          handling of this external entity.
+                        description: ExternalNode is the opaque identifier of the agent/controller responsible for additional processing or handling of this external entity.
                         type: string
                       ports:
                         description: Ports maintain the list of named ports.
                         items:
-                          description: NamedPort describes the port and protocol to
-                            match in a rule.
+                          description: NamedPort describes the port and protocol to match in a rule.
                           properties:
                             name:
                               description: Name associated with the Port.
@@ -1406,9 +972,7 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The protocol (TCP, UDP, or SCTP) which
-                                traffic must match. If not specified, this field defaults
-                                to TCP.
+                              description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
                               type: string
                           type: object
                         type: array
@@ -1424,10 +988,7 @@ spec:
                 description: Namespace of imported resource.
                 type: string
               raw:
-                description: 'If imported resource is ANP. TODO: ANP uses float64
-                  as priority.  Type float64 is discouraged by k8s, and is not supported
-                  by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec
-                  `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
+                description: 'If imported resource is ANP. TODO: ANP uses float64 as priority.  Type float64 is discouraged by k8s, and is not supported by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
                 properties:
                   data:
                     format: byte
@@ -1437,16 +998,10 @@ spec:
                 description: If imported resource is ServiceImport.
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   metadata:
                     type: object
@@ -1454,33 +1009,20 @@ spec:
                     description: spec defines the behavior of a ServiceImport.
                     properties:
                       ips:
-                        description: ip will be used as the VIP for this service when
-                          type is ClusterSetIP.
+                        description: ip will be used as the VIP for this service when type is ClusterSetIP.
                         items:
                           type: string
                         maxItems: 1
                         type: array
                       ports:
                         items:
-                          description: ServicePort represents the port on which the
-                            service is exposed
+                          description: ServicePort represents the port on which the service is exposed
                           properties:
                             appProtocol:
-                              description: The application protocol for this port.
-                                This field follows standard Kubernetes label syntax.
-                                Un-prefixed names are reserved for IANA standard service
-                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
-                                Non-standard protocols should use prefixed names such
-                                as mycompany.com/my-custom-protocol. Field can be
-                                enabled with ServiceAppProtocol feature gate.
+                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
                               type: string
                             name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
                               type: string
                             port:
                               description: The port that will be exposed by this service.
@@ -1488,8 +1030,7 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                           required:
                           - port
@@ -1497,31 +1038,22 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. Ignored when
-                          type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. Ignored when type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       sessionAffinityConfig:
-                        description: sessionAffinityConfig contains session affinity
-                          configuration.
+                        description: sessionAffinityConfig contains session affinity configuration.
                         properties:
                           clientIP:
-                            description: clientIP contains the configurations of Client
-                              IP based session affinity.
+                            description: clientIP contains the configurations of Client IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       type:
-                        description: type defines the type of this service. Must be
-                          ClusterSetIP or Headless.
+                        description: type defines the type of this service. Must be ClusterSetIP or Headless.
                         enum:
                         - ClusterSetIP
                         - Headless
@@ -1531,19 +1063,15 @@ spec:
                     - type
                     type: object
                   status:
-                    description: status contains information about the exported services
-                      that form the multi-cluster service referenced by this ServiceImport.
+                    description: status contains information about the exported services that form the multi-cluster service referenced by this ServiceImport.
                     properties:
                       clusters:
-                        description: clusters is the list of exporting clusters from
-                          which this service was derived.
+                        description: clusters is the list of exporting clusters from which this service was derived.
                         items:
-                          description: ClusterStatus contains service configuration
-                            mapped to a specific source cluster
+                          description: ClusterStatus contains service configuration mapped to a specific source cluster
                           properties:
                             cluster:
-                              description: cluster is the name of the exporting cluster.
-                                Must be a valid RFC-1123 DNS label.
+                              description: cluster is the name of the exporting cluster. Must be a valid RFC-1123 DNS label.
                               type: string
                           required:
                           - cluster
@@ -1556,37 +1084,31 @@ spec:
                 type: object
             type: object
           status:
-            description: ResourceImportStatus defines the observed state of ResourceImport
+            description: ResourceImportStatus defines the observed state of ResourceImport.
             properties:
               clusterStatuses:
                 items:
-                  description: ResourceImportClusterStatus indicates the readiness
-                    status of the ResourceImport in clusters
+                  description: ResourceImportClusterStatus indicates the readiness status of the ResourceImport in clusters.
                   properties:
                     clusterID:
                       description: ClusterID is the unique identifier of this cluster.
                       type: string
                     conditions:
                       items:
-                        description: ResourceImportCondition indicates the condition
-                          of the ResourceImport in a cluster
+                        description: ResourceImportCondition indicates the condition of the ResourceImport in a cluster.
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transited from one
-                              status to another
+                            description: Last time the condition transited from one status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details
-                              about the transition
+                            description: A human readable message indicating details about the transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the
-                              condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False,
-                              Unknown
+                            description: Status of the condition, one of True, False, Unknown.
                             type: string
                           type:
                             type: string
@@ -1607,15 +1129,230 @@ status:
   conditions: []
   storedVersions: []
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: serviceexports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  names:
+    kind: ServiceExport
+    plural: serviceexports
+    shortNames:
+    - svcex
+    singular: serviceexport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceExport declares that the Service with the same name and namespace as this export should be consumable from other clusters.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: status describes the current state of an exported service. Service configuration comes from the Service that had the same name and namespace as this ServiceExport. Populated by the multi-cluster service implementation's controller.
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: antrea
+  name: serviceimports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  names:
+    kind: ServiceImport
+    plural: serviceimports
+    shortNames:
+    - svcim
+    singular: serviceimport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The type of this ServiceImport
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The VIP for this ServiceImport
+      jsonPath: .spec.ips
+      name: IP
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceImport describes a service imported from clusters in a ClusterSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the behavior of a ServiceImport.
+            properties:
+              ips:
+                description: ip will be used as the VIP for this service when type is ClusterSetIP.
+                items:
+                  type: string
+                maxItems: 1
+                type: array
+              ports:
+                items:
+                  description: ServicePort represents the port on which the service is exposed
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                      type: string
+                    name:
+                      description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                      type: string
+                    port:
+                      description: The port that will be exposed by this service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                      type: string
+                  required:
+                  - port
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              sessionAffinity:
+                description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. Ignored when type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                type: string
+              sessionAffinityConfig:
+                description: sessionAffinityConfig contains session affinity configuration.
+                properties:
+                  clientIP:
+                    description: clientIP contains the configurations of Client IP based session affinity.
+                    properties:
+                      timeoutSeconds:
+                        description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              type:
+                description: type defines the type of this service. Must be ClusterSetIP or Headless.
+                enum:
+                - ClusterSetIP
+                - Headless
+                type: string
+            required:
+            - ports
+            - type
+            type: object
+          status:
+            description: status contains information about the exported services that form the multi-cluster service referenced by this ServiceImport.
+            properties:
+              clusters:
+                description: clusters is the list of exporting clusters from which this service was derived.
+                items:
+                  description: ClusterStatus contains service configuration mapped to a specific source cluster
+                  properties:
+                    cluster:
+                      description: cluster is the name of the exporting cluster. Must be a valid RFC-1123 DNS label.
+                      type: string
+                  required:
+                  - cluster
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - cluster
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-controller
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-leader-election-role
   namespace: kube-system
 rules:
@@ -1655,6 +1392,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app: antrea
   name: antrea-multicluster-controller-role
 rules:
 - apiGroups:
@@ -1843,6 +1582,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1853,6 +1594,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-proxy-role
 rules:
 - apiGroups:
@@ -1871,6 +1614,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-leader-election-rolebinding
   namespace: kube-system
 roleRef:
@@ -1885,6 +1630,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1898,6 +1645,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1924,6 +1673,8 @@ data:
       resourceName: 6536456a.crd.antrea.io
 kind: ConfigMap
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-manager-config
   namespace: kube-system
 ---
@@ -1931,6 +1682,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: antrea
     control-plane: antrea-multicluster-controller
   name: antrea-multicluster-controller-metrics-service
   namespace: kube-system
@@ -1940,11 +1692,14 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app: antrea
     control-plane: antrea-multicluster-controller
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-webhook-service
   namespace: kube-system
 spec:
@@ -1952,12 +1707,14 @@ spec:
   - port: 443
     targetPort: 9443
   selector:
+    app: antrea
     control-plane: antrea-multicluster-controller
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app: antrea
     control-plane: antrea-multicluster-controller
   name: antrea-multicluster-controller
   namespace: kube-system
@@ -1965,10 +1722,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: antrea
       control-plane: antrea-multicluster-controller
   template:
     metadata:
       labels:
+        app: antrea
         control-plane: antrea-multicluster-controller
     spec:
       containers:
@@ -2027,6 +1786,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-serving-cert
   namespace: kube-system
 spec:
@@ -2041,6 +1802,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-selfsigned-issuer
   namespace: kube-system
 spec:
@@ -2051,6 +1814,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+  labels:
+    app: antrea
   name: antrea-multicluster-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -2164,6 +1929,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+  labels:
+    app: antrea
   name: antrea-multicluster-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
I think we need serviceexports and serviceimports crds from [mcs](https://github.com/kubernetes-sigs/mcs-api/), otherwise, user have to install it manually via k8s mcs for antrea multi-cluster features.

Signed-off-by: Lan Luo <luola@vmware.com>