### PR TITLE
add resourceexport_controller

### DIFF
--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -47,21 +47,18 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
-vet: ## Run go vet against code.
-	go vet ./...
-
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet ## Run tests.
+test: manifests generate fmt ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 ##@ Build
 
-build: generate fmt vet ## Build manager binary.
+build: generate fmt ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/manager main.go
 
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests generate fmt ## Run a controller from your host.
 	go run ./main.go
 
 #docker-build: test ## Build docker image with the manager.

--- a/multicluster/apis/multicluster/v1alpha1/clusterclaim_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha1/clusterclaim_webhook.go
@@ -32,7 +32,7 @@ func (r *ClusterClaim) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-clusterclaim,mutating=true,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clusterclaims,verbs=create;update,versions=v1alpha1,name=mclusterclaim.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-clusterclaim,mutating=true,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clusterclaims,verbs=create;update,versions=v1alpha1,name=mclusterclaim.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &ClusterClaim{}
 
@@ -44,7 +44,7 @@ func (r *ClusterClaim) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-clusterclaim,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clusterclaims,verbs=create;update,versions=v1alpha1,name=vclusterclaim.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-clusterclaim,mutating=false,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clusterclaims,verbs=create;update,versions=v1alpha1,name=vclusterclaim.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &ClusterClaim{}
 

--- a/multicluster/apis/multicluster/v1alpha1/clusterset_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha1/clusterset_webhook.go
@@ -32,7 +32,7 @@ func (r *ClusterSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-clusterset,mutating=true,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clustersets,verbs=create;update,versions=v1alpha1,name=mclusterset.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-clusterset,mutating=true,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clustersets,verbs=create;update,versions=v1alpha1,name=mclusterset.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &ClusterSet{}
 
@@ -41,7 +41,7 @@ func (r *ClusterSet) Default() {
 	clustersetlog.Info("default", "name", r.Name)
 }
 
-//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-clusterset,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clustersets,verbs=create;update,versions=v1alpha1,name=vclusterset.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-clusterset,mutating=false,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clustersets,verbs=create;update,versions=v1alpha1,name=vclusterset.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &ClusterSet{}
 

--- a/multicluster/apis/multicluster/v1alpha1/memberclusterannounce_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha1/memberclusterannounce_webhook.go
@@ -32,7 +32,7 @@ func (r *MemberClusterAnnounce) SetupWebhookWithManager(mgr ctrl.Manager) error 
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce,mutating=true,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=memberclusterannounces,verbs=create;update,versions=v1alpha1,name=mmemberclusterannounce.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce,mutating=true,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=memberclusterannounces,verbs=create;update,versions=v1alpha1,name=mmemberclusterannounce.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &MemberClusterAnnounce{}
 
@@ -41,7 +41,7 @@ func (r *MemberClusterAnnounce) Default() {
 	memberclusterannouncelog.Info("default", "name", r.Name)
 }
 
-//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=memberclusterannounces,verbs=create;update,versions=v1alpha1,name=vmemberclusterannounce.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce,mutating=false,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=memberclusterannounces,verbs=create;update,versions=v1alpha1,name=vmemberclusterannounce.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &MemberClusterAnnounce{}
 

--- a/multicluster/apis/multicluster/v1alpha1/resourceexport_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha1/resourceexport_webhook.go
@@ -32,7 +32,7 @@ func (r *ResourceExport) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport,mutating=true,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=create;update,versions=v1alpha1,name=mresourceexport.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport,mutating=true,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=create;update,versions=v1alpha1,name=mresourceexport.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &ResourceExport{}
 
@@ -41,7 +41,7 @@ func (r *ResourceExport) Default() {
 	resourceexportlog.Info("default", "name", r.Name)
 }
 
-//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-resourceexport,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=create;update,versions=v1alpha1,name=vresourceexport.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-resourceexport,mutating=false,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=create;update,versions=v1alpha1,name=vresourceexport.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &ResourceExport{}
 

--- a/multicluster/apis/multicluster/v1alpha1/resourceimport_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha1/resourceimport_webhook.go
@@ -32,7 +32,7 @@ func (r *ResourceImport) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-resourceimport,mutating=true,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceimports,verbs=create;update,versions=v1alpha1,name=mresourceimport.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha1-resourceimport,mutating=true,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceimports,verbs=create;update,versions=v1alpha1,name=mresourceimport.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &ResourceImport{}
 
@@ -41,7 +41,7 @@ func (r *ResourceImport) Default() {
 	resourceimportlog.Info("default", "name", r.Name)
 }
 
-//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-resourceimport,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceimports,verbs=create;update,versions=v1alpha1,name=vresourceimport.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-resourceimport,mutating=false,failurePolicy=ignore,sideEffects=None,groups=multicluster.crd.antrea.io,resources=resourceimports,verbs=create;update,versions=v1alpha1,name=vresourceimport.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &ResourceImport{}
 

--- a/multicluster/config/multi-cluster.yaml
+++ b/multicluster/config/multi-cluster.yaml
@@ -1625,38 +1625,6 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: antrea
-  name: antrea-multicluster-metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: antrea
-  name: antrea-multicluster-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -1687,21 +1655,6 @@ subjects:
   name: antrea-multicluster-controller
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app: antrea
-  name: antrea-multicluster-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: antrea-multicluster-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: antrea-multicluster-controller
-  namespace: kube-system
----
 apiVersion: v1
 data:
   controller_manager_config.yaml: |
@@ -1722,23 +1675,6 @@ metadata:
     app: antrea
   name: antrea-multicluster-manager-config
   namespace: kube-system
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: antrea
-    control-plane: antrea-multicluster-controller
-  name: antrea-multicluster-controller-metrics-service
-  namespace: kube-system
-spec:
-  ports:
-  - name: https
-    port: 8443
-    targetPort: https
-  selector:
-    app: antrea
-    control-plane: antrea-multicluster-controller
 ---
 apiVersion: v1
 kind: Service
@@ -1871,7 +1807,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mclusterclaim.kb.io
   rules:
   - apiGroups:
@@ -1892,7 +1828,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterset
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mclusterset.kb.io
   rules:
   - apiGroups:
@@ -1913,7 +1849,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mmemberclusterannounce.kb.io
   rules:
   - apiGroups:
@@ -1934,7 +1870,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mresourceexport.kb.io
   rules:
   - apiGroups:
@@ -1955,7 +1891,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceimport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mresourceimport.kb.io
   rules:
   - apiGroups:
@@ -1986,7 +1922,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vclusterclaim.kb.io
   rules:
   - apiGroups:
@@ -2007,7 +1943,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vclusterset.kb.io
   rules:
   - apiGroups:
@@ -2028,7 +1964,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vmemberclusterannounce.kb.io
   rules:
   - apiGroups:
@@ -2049,7 +1985,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceexport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vresourceexport.kb.io
   rules:
   - apiGroups:
@@ -2070,7 +2006,7 @@ webhooks:
       name: antrea-multicluster-webhook-service
       namespace: kube-system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceimport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vresourceimport.kb.io
   rules:
   - apiGroups:

--- a/multicluster/config/multi-cluster.yaml
+++ b/multicluster/config/multi-cluster.yaml
@@ -1397,6 +1397,39 @@ metadata:
   name: antrea-multicluster-controller-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - multicluster.crd.antrea.io
   resources:
   - clusterclaims
@@ -1578,6 +1611,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/multicluster/config/rbac/kustomization.yaml
+++ b/multicluster/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+# - auth_proxy_service.yaml
+# - auth_proxy_role.yaml
+# - auth_proxy_role_binding.yaml
+# - auth_proxy_client_clusterrole.yaml

--- a/multicluster/config/rbac/role.yaml
+++ b/multicluster/config/rbac/role.yaml
@@ -7,6 +7,39 @@ metadata:
   name: controller-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - multicluster.crd.antrea.io
   resources:
   - clusterclaims
@@ -188,3 +221,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/multicluster/config/webhook/manifests.yaml
+++ b/multicluster/config/webhook/manifests.yaml
@@ -14,7 +14,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mclusterclaim.kb.io
   rules:
   - apiGroups:
@@ -35,7 +35,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterset
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mclusterset.kb.io
   rules:
   - apiGroups:
@@ -56,7 +56,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mmemberclusterannounce.kb.io
   rules:
   - apiGroups:
@@ -77,7 +77,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mresourceexport.kb.io
   rules:
   - apiGroups:
@@ -98,7 +98,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceimport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mresourceimport.kb.io
   rules:
   - apiGroups:
@@ -127,7 +127,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vclusterclaim.kb.io
   rules:
   - apiGroups:
@@ -148,7 +148,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vclusterset.kb.io
   rules:
   - apiGroups:
@@ -169,7 +169,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vmemberclusterannounce.kb.io
   rules:
   - apiGroups:
@@ -190,7 +190,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceexport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vresourceexport.kb.io
   rules:
   - apiGroups:
@@ -211,7 +211,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceimport
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vresourceimport.kb.io
   rules:
   - apiGroups:

--- a/multicluster/controllers/multicluster/helper.go
+++ b/multicluster/controllers/multicluster/helper.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 Antrea Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+const (
+	antreaMultiClusterServiceLabel = "antrea.io/multi-cluster"
+	ServiceKind                    = "Service"
+	EndpointsKind                  = "Endpoints"
+	ServiceImportKind              = "ServiceImport"
+)
+
+var LeaderNameSpace string
+var LocalClusterID string

--- a/multicluster/controllers/multicluster/resourceexport_controller.go
+++ b/multicluster/controllers/multicluster/resourceexport_controller.go
@@ -18,13 +18,17 @@ package multicluster
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,25 +41,39 @@ import (
 type (
 	// ResourceExportReconciler reconciles a ResourceExport object
 	ResourceExportReconciler struct {
-		Client             client.Client
-		Scheme             *runtime.Scheme
-		K8sClient          kubernetes.Interface
-		AntreamcsCrdClient antreamcsversioned.Interface
+		Client              client.Client
+		Scheme              *runtime.Scheme
+		AntreamcsCrdClient  antreamcsversioned.Interface
+		installedResExports cache.Indexer
 	}
+)
+
+const (
+	// cached indexer
+	resExportIndexerByNameKind = "resourceexport.by.namekind"
 )
 
 func NewResourceExportReconciler(
 	Client client.Client,
 	Scheme *runtime.Scheme,
-	k8sClient kubernetes.Interface,
 	antreamcsCrdClient antreamcsversioned.Interface) *ResourceExportReconciler {
 	reconciler := &ResourceExportReconciler{
-		Client:             Client,
-		Scheme:             Scheme,
-		K8sClient:          k8sClient,
-		AntreamcsCrdClient: antreamcsCrdClient,
+		Client:              Client,
+		Scheme:              Scheme,
+		AntreamcsCrdClient:  antreamcsCrdClient,
+		installedResExports: cache.NewIndexer(resExportIndexerKeyFunc, cache.Indexers{resExportIndexerByNameKind: resExportIndexerByNameKindFunc}),
 	}
 	return reconciler
+}
+
+func resExportIndexerKeyFunc(obj interface{}) (string, error) {
+	re := obj.(mcsv1alpha1.ResourceExport)
+	return re.Namespace + "/" + re.Name, nil
+}
+
+func resExportIndexerByNameKindFunc(obj interface{}) ([]string, error) {
+	re := obj.(mcsv1alpha1.ResourceExport)
+	return []string{re.Spec.Namespace + re.Spec.Name + re.Spec.ClusterID + re.Spec.Kind}, nil
 }
 
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=get;list;watch;create;update;patch;delete
@@ -63,92 +81,144 @@ func NewResourceExportReconciler(
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports/finalizers,verbs=update
 
 func (r *ResourceExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	klog.Infof("request namespace %s, name %s ", req.Namespace, req.Name)
-	//??? ResourceImport name will be the same name as ResourceExport
-	resImportName := req.Name
+	klog.V(2).Infof("reconcile for %s", req.NamespacedName)
 	var resExport mcsv1alpha1.ResourceExport
 	if err := r.Client.Get(ctx, req.NamespacedName, &resExport); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{})
-		if err != nil {
-			klog.Errorf("fail to delete ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
-			return ctrl.Result{}, client.IgnoreNotFound(err)
+		re, exist, _ := r.installedResExports.GetByKey(req.NamespacedName.String())
+		if !exist {
+			klog.Infof("no matched cache for %s", req.NamespacedName)
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, nil
+		existRe := re.(mcsv1alpha1.ResourceExport)
+		reList, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(req.Namespace).List(ctx,
+			metav1.ListOptions{LabelSelector: getLabelSelector(&existRe)})
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		resImportName := getResourceImportName(&existRe)
+		if len(reList.Items) == 0 {
+			klog.Info("cleanup ResourceImport %s/%s", req.Namespace, resImportName)
+			err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Delete(ctx, resImportName, metav1.DeleteOptions{})
+			if err != nil {
+				klog.Errorf("fail to delete ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
+				if apierrors.IsNotFound(err) {
+					r.installedResExports.Delete(re)
+					return ctrl.Result{}, nil
+				}
+				return ctrl.Result{}, err
+			}
+		}
+
+		uniqueIndex := existRe.Spec.Namespace + existRe.Spec.Name + existRe.Spec.ClusterID + EndpointsKind
+		epExportCache, err := r.installedResExports.ByIndex(resExportIndexerByNameKind, uniqueIndex)
+		if err != nil {
+			klog.Infof("fail to get cache, err: %v", err)
+			return ctrl.Result{}, err
+		}
+		if len(epExportCache) == 0 {
+			klog.Infof("no cache in installedResExports %s", req.NamespacedName)
+			return ctrl.Result{}, nil
+		} else if len(epExportCache) == 1 {
+			epExport := epExportCache[0].(mcsv1alpha1.ResourceExport)
+			resImport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Get(ctx, resImportName, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("fail to get ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			newResImport, changed := r.refreshResourceImport(&epExport, resImport, false)
+			if changed {
+				_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Update(ctx, newResImport, metav1.UpdateOptions{})
+				if err != nil {
+					klog.Errorf("fail to update ResourceImport %s/%s", req.Namespace, resImportName)
+					return ctrl.Result{}, err
+				}
+			}
+			r.installedResExports.Delete(epExport)
+		} else {
+			// this should never happen.
+			return ctrl.Result{}, fmt.Errorf("duplicate Endpoint type of ResourceExport")
+		}
 	}
 
 	importedResNameSpace := resExport.Labels["sourceNamespace"]
 	importedResName := resExport.Labels["sourceName"]
 	importedClusterID := resExport.Labels["sourceClusterID"]
-	// check the kind of ResourceExport
-	resImportBase := &mcsv1alpha1.ResourceImport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resImportName,
-			Namespace: req.Namespace,
-		},
-		Spec: mcsv1alpha1.ResourceImportSpec{
-			ClusterIDs: []string{},
-			Name:       importedResName,
-			Namespace:  importedResNameSpace,
-		},
-	}
-	resImport := r.refreshResourceImport(&resExport, resImportBase)
+	resImportName := getResourceImportName(&resExport)
+
+	var createResImport bool
 	existResImport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Get(ctx, resImportName, metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("fail to get ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Create(ctx, resImport, metav1.CreateOptions{})
-		if err != nil {
-			klog.Errorf("fail to create ResourceImport %s/%s,err: %v", req.Namespace, resImportName, err)
-			return ctrl.Result{}, err
-		}
-		newResImport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Get(ctx, resImportName, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("fail to get ResourceImport %s/%s", req.Namespace, resImportName)
-			return ctrl.Result{}, err
-		}
-		newResImport.Status = mcsv1alpha1.ResourceImportStatus{
-			ClusterStatuses: []mcsv1alpha1.ResourceImportClusterStatus{
-				{
-					ClusterID: importedClusterID,
-					Conditions: []mcsv1alpha1.ResourceImportCondition{{
-						Type:               mcsv1alpha1.ResourceImportSucceeded,
-						Status:             corev1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(time.Now()),
-						Message:            "creation is successful",
-					}},
-				},
+		existResImport = &mcsv1alpha1.ResourceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resImportName,
+				Namespace: req.Namespace,
+			},
+			Spec: mcsv1alpha1.ResourceImportSpec{
+				ClusterIDs: []string{},
+				Name:       importedResName,
+				Namespace:  importedResNameSpace,
 			},
 		}
-		if _, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Update(ctx, newResImport, metav1.UpdateOptions{}); err != nil {
-			klog.Errorf("fail to update ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
-			return ctrl.Result{}, err
+		createResImport = true
+	}
+
+	var latestResImport *mcsv1alpha1.ResourceImport
+	resImport, changed := r.refreshResourceImport(&resExport, existResImport, createResImport)
+	if changed {
+		if createResImport {
+			latestResImport, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Create(ctx, resImport, metav1.CreateOptions{})
+		} else {
+			latestResImport, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Update(ctx, resImport, metav1.UpdateOptions{})
 		}
+	} else {
 		return ctrl.Result{}, nil
 	}
 
-	updatedResImport := r.refreshResourceImport(&resExport, existResImport)
-	_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Update(ctx, updatedResImport, metav1.UpdateOptions{})
 	if err != nil {
-		klog.Errorf("fail to update ResourceImport %s/%s", req.Namespace, resImportName)
-		return ctrl.Result{}, err
+		if createResImport {
+			klog.Errorf("fail to create ResourceImport %s/%s,err: %v", req.Namespace, resImportName, err)
+			return ctrl.Result{}, err
+		} else {
+			klog.Errorf("fail to update ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
+			return ctrl.Result{}, err
+		}
 	}
-	existStatus := existResImport.DeepCopy().Status
-	existStatus.ClusterStatuses = append(existStatus.ClusterStatuses, mcsv1alpha1.ResourceImportClusterStatus{
+
+	_, exist, _ := r.installedResExports.GetByKey(req.NamespacedName.String())
+	if exist {
+		r.installedResExports.Update(resExport)
+	} else {
+		r.installedResExports.Add(resExport)
+	}
+
+	updatedStatus := existResImport.DeepCopy().Status
+	var message string
+	if createResImport {
+		message = "creation is successful"
+	} else {
+		message = "update is successful"
+	}
+
+	//TODO: should ResourceImport status be updated only by member cluster to tell the leader the service import status?
+	updatedStatus.ClusterStatuses = append(updatedStatus.ClusterStatuses, mcsv1alpha1.ResourceImportClusterStatus{
 		ClusterID: importedClusterID,
 		Conditions: []mcsv1alpha1.ResourceImportCondition{{
 			Type:               mcsv1alpha1.ResourceImportSucceeded,
 			Status:             corev1.ConditionTrue,
 			LastTransitionTime: metav1.NewTime(time.Now()),
-			Message:            "update is successful",
+			Message:            message,
 		}},
 	})
-	updatedResImport.Status = existStatus
-	if _, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).UpdateStatus(ctx, existResImport, metav1.UpdateOptions{}); err != nil {
+	latestResImport.Status = updatedStatus
+	if _, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).UpdateStatus(ctx, latestResImport, metav1.UpdateOptions{}); err != nil {
 		klog.Errorf("fail to update ResourceImport Status %s/%s, err: %v", req.Namespace, resImportName, err)
 		return ctrl.Result{}, err
 	}
@@ -157,24 +227,53 @@ func (r *ResourceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 func (r *ResourceExportReconciler) refreshResourceImport(
 	resExport *mcsv1alpha1.ResourceExport,
-	resImport *mcsv1alpha1.ResourceImport) *mcsv1alpha1.ResourceImport {
+	resImport *mcsv1alpha1.ResourceImport,
+	createResImport bool) (*mcsv1alpha1.ResourceImport, bool) {
+	newResImport := resImport.DeepCopy()
 	switch resExport.Spec.Kind {
 	case ServiceKind:
-		resImport.Spec.Kind = ServiceImportKind
-		resImport.Spec.ServiceImport = &mcs.ServiceImport{
-			Spec: mcs.ServiceImportSpec{
-				Ports: svcPortsConverter(resExport.Spec.Service.ServiceSpec.Ports),
-				Type:  mcs.ClusterSetIP,
-				IPs:   []string{resExport.Spec.Service.ServiceSpec.ClusterIP},
-			},
+		newResImport.Spec.Kind = ServiceImportKind
+		if createResImport {
+			newResImport.Spec.ServiceImport = &mcs.ServiceImport{
+				Spec: mcs.ServiceImportSpec{
+					Ports: svcPortsConverter(resExport.Spec.Service.ServiceSpec.Ports),
+					Type:  mcs.ClusterSetIP,
+					IPs:   []string{},
+				},
+			}
+			return newResImport, true
 		}
+		convertedPorts := svcPortsConverter(resExport.Spec.Service.ServiceSpec.Ports)
+		if !apiequality.Semantic.DeepEqual(newResImport.Spec.ServiceImport.Spec.Ports, convertedPorts) {
+			klog.Infof("new ResourceExport ports %v doesn't match with ResourceImport Ports %v,skip it", resExport.Spec.Service.ServiceSpec.Ports, newResImport.Spec.ServiceImport.Spec.Ports)
+			// TODO: update ResourceExport status to reflect port collision?
+		}
+		return newResImport, false
 	case EndpointsKind:
 		resImport.Spec.Kind = EndpointsKind
-		resImport.Spec.Endpoints = &mcsv1alpha1.EndpointsImport{
-			Subsets: resExport.Spec.Endpoints.Subsets,
+		if createResImport {
+			resImport.Spec.Endpoints = &mcsv1alpha1.EndpointsImport{
+				Subsets: resExport.Spec.Endpoints.Subsets,
+			}
+			return newResImport, true
 		}
+		// check all mateched Endpoints ResourceExport and generate a new EndpointSubset
+		var newSubsets []corev1.EndpointSubset
+		reList, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(resExport.Namespace).List(context.TODO(),
+			metav1.ListOptions{
+				LabelSelector: getLabelSelector(resExport),
+			})
+		if err != nil {
+			klog.Errorf("fail to list ResourceExports %v, no update to exist ResourceImport", err)
+			return newResImport, false
+		}
+		for _, re := range reList.Items {
+			newSubsets = append(newSubsets, re.Spec.Endpoints.Subsets...)
+		}
+		newResImport.Spec.Endpoints = &mcsv1alpha1.EndpointsImport{Subsets: newSubsets}
+		return newResImport, true
 	}
-	return resImport
+	return newResImport, false
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -184,15 +283,22 @@ func (r *ResourceExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+func getLabelSelector(resExport *mcsv1alpha1.ResourceExport) string {
+	return "sourceNamespace=" + resExport.Spec.Namespace + ",sourceName=" + resExport.Spec.Name + ",sourceKind=" + resExport.Spec.Kind
+}
+
 func svcPortsConverter(svcPort []corev1.ServicePort) []mcs.ServicePort {
 	var mcsSP []mcs.ServicePort
 	for _, v := range svcPort {
 		mcsSP = append(mcsSP, mcs.ServicePort{
-			Name:        v.Name,
-			Port:        v.Port,
-			Protocol:    v.Protocol,
-			AppProtocol: v.AppProtocol,
+			Name:     strconv.Itoa(int(v.Port)) + string(v.Protocol),
+			Port:     v.Port,
+			Protocol: v.Protocol,
 		})
 	}
 	return mcsSP
+}
+
+func getResourceImportName(resExport *mcsv1alpha1.ResourceExport) string {
+	return resExport.Spec.Namespace + "-" + resExport.Spec.Name + "-" + strings.ToLower(resExport.Spec.Kind)
 }

--- a/multicluster/controllers/multicluster/resourceexport_controller.go
+++ b/multicluster/controllers/multicluster/resourceexport_controller.go
@@ -18,45 +18,181 @@ package multicluster
 
 import (
 	"context"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
-	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	antreamcsversioned "antrea.io/antrea/multicluster/pkg/client/clientset/versioned"
 )
 
-// ResourceExportReconciler reconciles a ResourceExport object
-type ResourceExportReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
+type (
+	// ResourceExportReconciler reconciles a ResourceExport object
+	ResourceExportReconciler struct {
+		Client             client.Client
+		Scheme             *runtime.Scheme
+		K8sClient          kubernetes.Interface
+		AntreamcsCrdClient antreamcsversioned.Interface
+	}
+)
+
+func NewResourceExportReconciler(
+	Client client.Client,
+	Scheme *runtime.Scheme,
+	k8sClient kubernetes.Interface,
+	antreamcsCrdClient antreamcsversioned.Interface) *ResourceExportReconciler {
+	reconciler := &ResourceExportReconciler{
+		Client:             Client,
+		Scheme:             Scheme,
+		K8sClient:          k8sClient,
+		AntreamcsCrdClient: antreamcsCrdClient,
+	}
+	return reconciler
 }
 
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ResourceExport object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ResourceExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	klog.Infof("request namespace %s, name %s ", req.Namespace, req.Name)
+	//??? ResourceImport name will be the same name as ResourceExport
+	resImportName := req.Name
+	var resExport mcsv1alpha1.ResourceExport
+	if err := r.Client.Get(ctx, req.NamespacedName, &resExport); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Errorf("fail to delete ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return ctrl.Result{}, nil
+	}
 
-	// your logic here
+	importedResNameSpace := resExport.Labels["sourceNamespace"]
+	importedResName := resExport.Labels["sourceName"]
+	importedClusterID := resExport.Labels["sourceClusterID"]
+	// check the kind of ResourceExport
+	resImportBase := &mcsv1alpha1.ResourceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resImportName,
+			Namespace: req.Namespace,
+		},
+		Spec: mcsv1alpha1.ResourceImportSpec{
+			ClusterIDs: []string{},
+			Name:       importedResName,
+			Namespace:  importedResNameSpace,
+		},
+	}
+	resImport := r.refreshResourceImport(&resExport, resImportBase)
+	existResImport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Get(ctx, resImportName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("fail to get ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Create(ctx, resImport, metav1.CreateOptions{})
+		if err != nil {
+			klog.Errorf("fail to create ResourceImport %s/%s,err: %v", req.Namespace, resImportName, err)
+			return ctrl.Result{}, err
+		}
+		newResImport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Get(ctx, resImportName, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("fail to get ResourceImport %s/%s", req.Namespace, resImportName)
+			return ctrl.Result{}, err
+		}
+		newResImport.Status = mcsv1alpha1.ResourceImportStatus{
+			ClusterStatuses: []mcsv1alpha1.ResourceImportClusterStatus{
+				{
+					ClusterID: importedClusterID,
+					Conditions: []mcsv1alpha1.ResourceImportCondition{{
+						Type:               mcsv1alpha1.ResourceImportSucceeded,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(time.Now()),
+						Message:            "creation is successful",
+					}},
+				},
+			},
+		}
+		if _, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Update(ctx, newResImport, metav1.UpdateOptions{}); err != nil {
+			klog.Errorf("fail to update ResourceImport %s/%s, err: %v", req.Namespace, resImportName, err)
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
 
+	updatedResImport := r.refreshResourceImport(&resExport, existResImport)
+	_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).Update(ctx, updatedResImport, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("fail to update ResourceImport %s/%s", req.Namespace, resImportName)
+		return ctrl.Result{}, err
+	}
+	existStatus := existResImport.DeepCopy().Status
+	existStatus.ClusterStatuses = append(existStatus.ClusterStatuses, mcsv1alpha1.ResourceImportClusterStatus{
+		ClusterID: importedClusterID,
+		Conditions: []mcsv1alpha1.ResourceImportCondition{{
+			Type:               mcsv1alpha1.ResourceImportSucceeded,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+			Message:            "update is successful",
+		}},
+	})
+	updatedResImport.Status = existStatus
+	if _, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceImports(req.Namespace).UpdateStatus(ctx, existResImport, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("fail to update ResourceImport Status %s/%s, err: %v", req.Namespace, resImportName, err)
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
+}
+
+func (r *ResourceExportReconciler) refreshResourceImport(
+	resExport *mcsv1alpha1.ResourceExport,
+	resImport *mcsv1alpha1.ResourceImport) *mcsv1alpha1.ResourceImport {
+	switch resExport.Spec.Kind {
+	case ServiceKind:
+		resImport.Spec.Kind = ServiceImportKind
+		resImport.Spec.ServiceImport = &mcs.ServiceImport{
+			Spec: mcs.ServiceImportSpec{
+				Ports: svcPortsConverter(resExport.Spec.Service.ServiceSpec.Ports),
+				Type:  mcs.ClusterSetIP,
+				IPs:   []string{resExport.Spec.Service.ServiceSpec.ClusterIP},
+			},
+		}
+	case EndpointsKind:
+		resImport.Spec.Kind = EndpointsKind
+		resImport.Spec.Endpoints = &mcsv1alpha1.EndpointsImport{
+			Subsets: resExport.Spec.Endpoints.Subsets,
+		}
+	}
+	return resImport
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ResourceExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multiclusterv1alpha1.ResourceExport{}).
+		For(&mcsv1alpha1.ResourceExport{}).
 		Complete(r)
+}
+
+func svcPortsConverter(svcPort []corev1.ServicePort) []mcs.ServicePort {
+	var mcsSP []mcs.ServicePort
+	for _, v := range svcPort {
+		mcsSP = append(mcsSP, mcs.ServicePort{
+			Name:        v.Name,
+			Port:        v.Port,
+			Protocol:    v.Protocol,
+			AppProtocol: v.AppProtocol,
+		})
+	}
+	return mcsSP
 }

--- a/multicluster/controllers/multicluster/serviceexport_controller.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller.go
@@ -1,0 +1,516 @@
+/*
+Copyright 2021 Antrea AuthorsvcExport.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	k8smcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	k8smcsversioned "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned"
+
+	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	antreamcsversioned "antrea.io/antrea/multicluster/pkg/client/clientset/versioned"
+)
+
+type (
+	svcInfo struct {
+		name       string
+		namespace  string
+		clusterIPs []string
+		ports      []corev1.ServicePort
+		svcType    string
+	}
+
+	epInfo struct {
+		name       string
+		namespace  string
+		addressIPs []string
+		ports      []corev1.EndpointPort
+		labels     map[string]string
+	}
+
+	// ServiceExportReconciler reconciles a ServiceExport object
+	ServiceExportReconciler struct {
+		Client          client.Client
+		Scheme          *runtime.Scheme
+		K8sClient       kubernetes.Interface
+		LeaderK8sClient kubernetes.Interface
+		K8smcsCrdClient k8smcsversioned.Interface
+		//TODO when leader HA is enabled, need a way to refresh AntreamcsCrdClient
+		AntreamcsCrdClient antreamcsversioned.Interface
+		installedSvcs      cache.Indexer
+		installedEps       cache.Indexer
+	}
+)
+
+const (
+	// cached indexer
+	svcIndexerByType                     = "service.by.type"
+	epIndexerByLabel                     = "endpoints.by.label"
+	nodeIndexerByServiceName             = "node.by.serviceName"
+	resExportIndexerByKind               = "resourceexport.by.kind"
+	resExportIndexerByNameSpacedNameKind = "resourceexport.by.namespacedNameKind"
+)
+
+func NewServiceExportReconciler(
+	Client client.Client,
+	Scheme *runtime.Scheme,
+	k8sClient kubernetes.Interface,
+	k8smcsCrdClient k8smcsversioned.Interface,
+	antreamcsCrdClient antreamcsversioned.Interface) *ServiceExportReconciler {
+	reconciler := &ServiceExportReconciler{
+		Client:             Client,
+		Scheme:             Scheme,
+		K8sClient:          k8sClient,
+		K8smcsCrdClient:    k8smcsCrdClient,
+		AntreamcsCrdClient: antreamcsCrdClient,
+		installedSvcs: cache.NewIndexer(svcInfoKeyFunc, cache.Indexers{
+			svcIndexerByType: svcIndexerByTypeFunc,
+		}),
+		installedEps: cache.NewIndexer(epInfoKeyFunc, cache.Indexers{
+			epIndexerByLabel: epIndexerByLabelFunc,
+		}),
+	}
+	return reconciler
+}
+
+func svcInfoKeyFunc(obj interface{}) (string, error) {
+	svc := obj.(*svcInfo)
+	return svc.namespace + svc.name, nil
+}
+
+func svcIndexerByTypeFunc(obj interface{}) ([]string, error) {
+	return []string{obj.(*svcInfo).svcType}, nil
+}
+
+func epInfoKeyFunc(obj interface{}) (string, error) {
+	ep := obj.(*epInfo)
+	return ep.namespace + ep.name, nil
+}
+
+func epIndexerByLabelFunc(obj interface{}) ([]string, error) {
+	var info []string
+	ep := obj.(*epInfo)
+	for k, v := range ep.labels {
+		info = append(info, k+v)
+	}
+	return info, nil
+}
+
+//+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=resourceexports/finalizers,verbs=update
+//+kubebuilder:rbac:groups="multicluster.x-k8s.io",resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+
+func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.Infof("request namespace %s, name %s ", req.NamespacedName, req.Name)
+	var svcExport k8smcsv1alpha1.ServiceExport
+	clusterID := LocalClusterID
+
+	key := getKey(req)
+	svcObj, svcInstalled, _ := r.installedSvcs.GetByKey(key)
+	epObj, epInstalled, _ := r.installedEps.GetByKey(key)
+	resExportBaseName := clusterID + "-" + req.Namespace + "-" + req.Name
+	svcResExportName := getResourceExportName(resExportBaseName, ServiceKind)
+	epResExportName := getResourceExportName(resExportBaseName, EndpointsKind)
+
+	if err := r.Client.Get(ctx, req.NamespacedName, &svcExport); err != nil {
+		klog.Infof("unable to fetch ServiceExport %s/%s, err: %v", req.Namespace, req.Name, err)
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		// clean up Service/Endpoints kind of ResourceExport in leader cluster
+		klog.Infof("deleting ResourceExport %s/%s in Leader Cluster", LeaderNameSpace, svcResExportName)
+		err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Delete(ctx, svcResExportName, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Errorf("fail to delete ResourceExport %s/%s, err: %v", LeaderNameSpace, svcResExportName, err)
+		}
+		klog.Infof("deleting ResourceExport %s/%s in Leader Cluster", LeaderNameSpace, epResExportName)
+		err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Delete(ctx, epResExportName, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Errorf("fail to delete ResourceExport %s/%s, err: %v", req.Namespace, epResExportName, err)
+		}
+		if svcInstalled {
+			_ = r.installedSvcs.Delete(svcObj)
+		}
+		if epInstalled {
+			_ = r.installedEps.Delete(epObj)
+		}
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// check if corresponding service exists or not, if it's deleted
+	// then need to clean up ServiceExport
+	svc, err := r.K8sClient.CoreV1().Services(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			err = r.K8smcsCrdClient.MulticlusterV1alpha1().ServiceExports(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+		} else {
+			klog.Errorf("fail to get Service %s/%s, err: %v", req.Namespace, req.Name, err)
+			return ctrl.Result{}, err
+		}
+	}
+
+	// we also watch Service and Endpoints events via events mapping function
+	// need to check cache and compare with cache if there is any change for Service or Endpoints
+	var svcNoChange, epNoChange bool
+	if svcInstalled {
+		installedSvc := svcObj.(*svcInfo)
+		if reflect.DeepEqual(svc.Spec.Ports, installedSvc.ports) &&
+			reflect.DeepEqual(svc.Spec.ClusterIPs, installedSvc.clusterIPs) {
+			klog.Infof("Service %s/%s has been converted into ResourceExport %s/%s and no change, skip it", svc.Namespace, svc.Name, LeaderNameSpace, svcResExportName)
+			svcNoChange = true
+		}
+	}
+
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
+			Labels: map[string]string{
+				"SourceServiceType": string(corev1.ServiceTypeNodePort),
+			},
+		},
+	}
+
+	if svc.Spec.Type == corev1.ServiceTypeNodePort {
+		// Build up Endpoint with Node ip and nodePort for NodePort service.
+		nodes, err := r.K8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: "spec.unschedulable=false"})
+		if err != nil {
+			klog.Error("fail to get nodes list")
+			return ctrl.Result{}, err
+		}
+		var addresses []corev1.EndpointAddress
+		for _, n := range nodes.Items {
+			for _, a := range n.Status.Addresses {
+				// prefer to use external IP?
+				if a.Type == corev1.NodeExternalIP {
+					addresses = append(addresses, corev1.EndpointAddress{IP: a.Address})
+					break
+				}
+				if a.Type == corev1.NodeInternalIP {
+					addresses = append(addresses, corev1.EndpointAddress{IP: a.Address})
+					break
+				}
+			}
+		}
+
+		var ports []corev1.EndpointPort
+		for _, p := range svc.Spec.Ports {
+			ports = append(ports, corev1.EndpointPort{
+				Port:     p.NodePort,
+				Protocol: p.Protocol,
+			})
+		}
+		ep.Subsets = []corev1.EndpointSubset{{Addresses: addresses, Ports: ports}}
+	} else {
+		ep, err = r.K8sClient.CoreV1().Endpoints(svcExport.Namespace).Get(ctx, svcExport.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("fail to get Endpoints %s/%s, err: %v", svcExport.Namespace, svcExport.Name, err)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+
+	if epInstalled {
+		installedEp := epObj.(*epInfo)
+		if reflect.DeepEqual(getEndPointsPorts(ep), installedEp.ports) &&
+			reflect.DeepEqual(getEndPointsAddress(ep), installedEp.addressIPs) {
+			klog.Infof("Endpoints %s/%s has been converted into ResourceExport %s/%s and no change, skip it", ep.Namespace, ep.Name, LeaderNameSpace, epResExportName)
+			epNoChange = true
+		}
+	}
+
+	if epNoChange && svcNoChange {
+		return ctrl.Result{}, nil
+	}
+
+	re := mcsv1alpha1.ResourceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: LeaderNameSpace,
+			Labels: map[string]string{
+				"sourceName":      req.Name,
+				"sourceNamespace": req.Namespace,
+				"sourceClusterID": clusterID,
+			},
+		},
+		Spec: mcsv1alpha1.ResourceExportSpec{
+			ClusterID: clusterID,
+			Name:      req.Name,
+			Namespace: req.Namespace,
+		},
+	}
+
+	if !svcNoChange {
+		klog.Infof("Service %s/%s has new changes, apply into ResourceExport %s/%s", svc.Namespace, svc.Name, LeaderNameSpace, svcResExportName)
+		err := r.serviceHandler(ctx, req, svc, svcResExportName, re)
+		if err != nil {
+			klog.Infof("fail to handle service change %s/%s, err: %v", svc.Namespace, svc.Name, err)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if !epNoChange {
+		klog.Infof("Endpoints %s/%s have new change, apply into ResourceExport %s/%s", ep.Namespace, ep.Name, LeaderNameSpace, epResExportName)
+		err := r.endpointsHandler(ctx, req, ep, epResExportName, re)
+		if err != nil {
+			klog.Infof("fail to handle service change %s/%s, err: %v", svc.Namespace, svc.Name, err)
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ServiceExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&k8smcsv1alpha1.ServiceExport{}).
+		Watches(&source.Kind{Type: &corev1.Service{}}, handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
+			if _, ok := a.(*corev1.Service).Labels[antreaMultiClusterServiceLabel]; ok {
+				// events mapping from Service to ServiceExport
+				return []reconcile.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Name:      a.GetName(),
+							Namespace: a.GetNamespace(),
+						},
+					},
+				}
+			}
+			return nil
+		})).
+		Watches(&source.Kind{Type: &corev1.Endpoints{}}, handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
+			if _, ok := a.(*corev1.Endpoints).Labels[antreaMultiClusterServiceLabel]; ok {
+				// events mapping from Endpoints to ServiceExport
+				return []reconcile.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Name:      a.GetName(),
+							Namespace: a.GetNamespace(),
+						},
+					},
+				}
+			}
+			return nil
+		})).Complete(r)
+}
+
+// serviceHandler handle service related change
+// - ClusterIP: update corresponding ResourceExport only when ClusterIP or Ports change.
+// - NodePort: update corresponding ResourceExport only when ClusterIP or Ports change.
+// ...
+func (r *ServiceExportReconciler) serviceHandler(
+	ctx context.Context,
+	req ctrl.Request,
+	svc *corev1.Service,
+	resName string,
+	re mcsv1alpha1.ResourceExport) error {
+	kind := ServiceKind
+	sinfo := &svcInfo{
+		name:       svc.Name,
+		namespace:  svc.Namespace,
+		clusterIPs: svc.Spec.ClusterIPs,
+		ports:      svc.Spec.Ports,
+		svcType:    string(svc.Spec.Type),
+	}
+	r.refreshResourceExport(resName, kind, svc, nil, &re)
+	existResExport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Get(ctx, resName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("fail to get ResourceExport %s/%s, err: %v", LeaderNameSpace, resName, err)
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err = r.createResourceExport(resName, ctx, req, &re); err != nil {
+			return err
+		}
+		// update Service's label with `antrea.io/multi-cluster` so we can watch Service's events via event mapping function.
+		labels := svc.DeepCopy().Labels
+		labels[antreaMultiClusterServiceLabel] = "true"
+		svc.Labels = labels
+		if _, err := r.K8sClient.CoreV1().Services(svc.Namespace).Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
+			klog.Infof("fail to update Service %s/%s's labels, err: %v", svc.Namespace, svc.Name, err)
+		}
+		r.installedSvcs.Add(sinfo)
+		return nil
+	}
+	if err := r.updateResourceExport(resName, ctx, req, &re, existResExport); err != nil {
+		return err
+	}
+	r.installedSvcs.Add(sinfo)
+	return nil
+}
+
+// endpointsHandler handle Endpoints related change
+// - update corresponding ResourceExport only when Ports or Addresses IP change.
+func (r *ServiceExportReconciler) endpointsHandler(
+	ctx context.Context,
+	req ctrl.Request,
+	ep *corev1.Endpoints,
+	resName string,
+	re mcsv1alpha1.ResourceExport) error {
+	kind := EndpointsKind
+	epInfo := &epInfo{
+		name:       ep.Name,
+		namespace:  ep.Namespace,
+		addressIPs: getEndPointsAddress(ep),
+		ports:      getEndPointsPorts(ep),
+		labels:     ep.Labels,
+	}
+	r.refreshResourceExport(resName, kind, nil, ep, &re)
+	existResExport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Get(ctx, resName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("fail to get ResourceExport %s/%s, err: %v", LeaderNameSpace, resName, err)
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := r.createResourceExport(resName, ctx, req, &re); err != nil {
+			return err
+		}
+		r.installedEps.Add(epInfo)
+		return nil
+	}
+	if err := r.updateResourceExport(resName, ctx, req, &re, existResExport); err != nil {
+		return err
+	}
+	r.installedEps.Add(epInfo)
+	return nil
+}
+func (r *ServiceExportReconciler) refreshResourceExport(resName, kind string,
+	svc *corev1.Service,
+	ep *corev1.Endpoints,
+	re *mcsv1alpha1.ResourceExport) mcsv1alpha1.ResourceExport {
+	re.Spec.Kind = kind
+	switch kind {
+	case ServiceKind:
+		re.ObjectMeta.Name = resName
+		re.Spec.Service = &mcsv1alpha1.ServiceExport{
+			ServiceSpec: svc.Spec,
+		}
+	case EndpointsKind:
+		re.ObjectMeta.Name = resName
+		re.Spec.Endpoints = &mcsv1alpha1.EndpointsExport{
+			Subsets: ep.Subsets,
+		}
+	}
+	return *re
+}
+
+func (r *ServiceExportReconciler) updateResourceExport(resName string,
+	ctx context.Context,
+	req ctrl.Request,
+	newResExport *mcsv1alpha1.ResourceExport,
+	existResExport *mcsv1alpha1.ResourceExport) error {
+	newResExport.ObjectMeta.ResourceVersion = existResExport.ObjectMeta.ResourceVersion
+	_, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Update(ctx, newResExport, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Infof("fail to update ResourceExport %s/%s, err:%v", LeaderNameSpace, resName, err)
+		return err
+	}
+	// ignore status update failure?
+	latestResExport, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Get(ctx, resName, metav1.GetOptions{})
+	if err != nil {
+		klog.Infof("fail to get ResourceExport %v", err)
+		return nil
+	}
+	latestResExport.Status.Conditions = []mcsv1alpha1.ResourceExportCondition{{
+		Type:               mcsv1alpha1.ResourceExportSucceeded,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Message:            "update is successful",
+	}}
+	_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).UpdateStatus(ctx, latestResExport, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Infof("fail to update ResourceExport's Status %s/%s,err:%v", LeaderNameSpace, resName, err)
+	}
+	return nil
+}
+
+func (r *ServiceExportReconciler) createResourceExport(resName string,
+	ctx context.Context,
+	req ctrl.Request,
+	re *mcsv1alpha1.ResourceExport) error {
+	klog.Infof("creating ResourceExport %s/%s", LeaderNameSpace, resName)
+	_, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Create(ctx, re, metav1.CreateOptions{})
+	if err != nil {
+		klog.Errorf("fail to create ResourceExport %s/%s in leader cluster,err: %v", LeaderNameSpace, resName, err)
+		return err
+	}
+	// ignore status update failure?
+	re.Status.Conditions = []mcsv1alpha1.ResourceExportCondition{{
+		Type:               mcsv1alpha1.ResourceExportSucceeded,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Message:            "creation is successful",
+	}}
+	new, err := r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).Get(ctx, resName, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	re.ObjectMeta.ResourceVersion = new.ObjectMeta.ResourceVersion
+	_, err = r.AntreamcsCrdClient.MulticlusterV1alpha1().ResourceExports(LeaderNameSpace).UpdateStatus(ctx, re, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Infof("fail to update ResourceExport's Status %s/%s,err:%v", LeaderNameSpace, resName, err)
+	}
+	return nil
+}
+
+func getKey(req ctrl.Request) string {
+	return req.Namespace + req.Name
+}
+
+func getResourceExportName(resName, kind string) string {
+	return resName + "-" + strings.ToLower(kind)
+}
+
+func getEndPointsAddress(ep *corev1.Endpoints) []string {
+	var epAddrs []string
+	for _, s := range ep.Subsets {
+		for _, a := range s.Addresses {
+			epAddrs = append(epAddrs, a.IP)
+		}
+	}
+	return epAddrs
+}
+
+func getEndPointsPorts(ep *corev1.Endpoints) []corev1.EndpointPort {
+	var epPorts []corev1.EndpointPort
+	for _, s := range ep.Subsets {
+		epPorts = append(epPorts, s.Ports...)
+	}
+	return epPorts
+}

--- a/multicluster/controllers/multicluster/serviceexport_controller.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Antrea AuthorsvcExport.
+Copyright 2021 Antrea Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/multicluster/main.go
+++ b/multicluster/main.go
@@ -17,22 +17,30 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	k8smcsversioned "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned"
+	mcsscheme "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/scheme"
 
-	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
-	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
+	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcscontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
+	mcsClient "antrea.io/antrea/multicluster/pkg/client/clientset/versioned"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -43,22 +51,30 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	utilruntime.Must(multiclusterv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(mcsscheme.AddToScheme(scheme))
+	utilruntime.Must(mcsv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
+
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
 
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var member bool
+	var leader bool
 	var probeAddr string
 	var config string
+	var namespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&member, "member", true, "Join the ClusterSet as a member")
+	flag.BoolVar(&leader, "leader", false, "Join the ClusterSet as a leader")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&config, "config", "", "Configuration file path.")
+	flag.StringVar(&namespace, "namespace", "kube-system", "Controller's default Namespace")
 
 	opts := zap.Options{
 		Development: true,
@@ -67,8 +83,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	k8sConfig := ctrl.GetConfigOrDie()
+	mgr, err := ctrl.NewManager(k8sConfig, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
@@ -81,72 +97,157 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&multiclustercontrollers.ClusterClaimReconciler{
+	ctx := context.Background()
+	crdClient := mcsClient.NewForConfigOrDie(k8sConfig)
+	memberAnnounces, err := crdClient.MulticlusterV1alpha1().MemberClusterAnnounces(namespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		setupLog.Error(err, "unable to get MemberClusterAnnounce list")
+		os.Exit(1)
+	}
+	if len(memberAnnounces.Items) == 0 {
+		setupLog.Error(err, "unable to get MemberClusterAnnounce information")
+		os.Exit(1)
+	}
+	// suppose there is only one MemberAnnounce
+	// will Saas support a member to join multiple ClusterSet?
+	m := memberAnnounces.Items[0]
+	clusterSet, err := crdClient.MulticlusterV1alpha1().ClusterSets(namespace).Get(ctx, m.ClusterSetID, v1.GetOptions{})
+	if err != nil {
+		setupLog.Error(err, "fail to get ClusterSet information")
+		os.Exit(1)
+	}
+
+	var leaderCluster mcsv1alpha1.MemberCluster
+	var leaderFound bool
+	for _, l := range clusterSet.Spec.Leaders {
+		if l.ClusterID == m.LeaderClusterID {
+			leaderCluster = l
+			leaderFound = true
+			break
+		}
+	}
+
+	if !leaderFound {
+		setupLog.Error(err, "fail to get Leader Cluster information")
+		os.Exit(1)
+	}
+
+	mcscontrollers.LeaderNameSpace = clusterSet.Spec.Namespace
+	mcscontrollers.LocalClusterID = m.ClusterID
+	// read secret in local cluster for leader cluster access
+	kubeClient, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		klog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+	}
+
+	accessInfo, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, leaderCluster.Secret, v1.GetOptions{})
+	if err != nil {
+		klog.Fatalf("Error getting secret %s : %s", leaderCluster.Secret, err.Error())
+	}
+	tlsClientConfig := rest.TLSClientConfig{}
+	tlsClientConfig.CAData = accessInfo.Data["ca.crt"]
+	bearerToken := accessInfo.Data["token"]
+	leaderConfig := rest.Config{
+		Host:            leaderCluster.Server,
+		TLSClientConfig: tlsClientConfig,
+		BearerToken:     string(bearerToken),
+	}
+
+	if err = (&mcscontrollers.ClusterClaimReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterClaim")
 		os.Exit(1)
 	}
-	if err = (&multiclustercontrollers.MemberClusterAnnounceReconciler{
+	if err = (&mcscontrollers.MemberClusterAnnounceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MemberClusterAnnounce")
 		os.Exit(1)
 	}
-	if err = (&multiclustercontrollers.ClusterSetReconciler{
+	if err = (&mcscontrollers.ClusterSetReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterSet")
 		os.Exit(1)
 	}
-	if err = (&multiclustercontrollers.ResourceExportFilterReconciler{
+	if err = (&mcscontrollers.ResourceExportFilterReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ResourceExportFilter")
 		os.Exit(1)
 	}
-	if err = (&multiclustercontrollers.ResourceImportFilterReconciler{
+	if err = (&mcscontrollers.ResourceImportFilterReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ResourceImportFilter")
 		os.Exit(1)
 	}
-	if err = (&multiclusterv1alpha1.ClusterClaim{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&mcsv1alpha1.ClusterClaim{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterClaim")
 		os.Exit(1)
 	}
-	if err = (&multiclusterv1alpha1.ClusterSet{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&mcsv1alpha1.ClusterSet{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterSet")
 		os.Exit(1)
 	}
-	if err = (&multiclusterv1alpha1.MemberClusterAnnounce{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&mcsv1alpha1.MemberClusterAnnounce{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "MemberClusterAnnounce")
 		os.Exit(1)
 	}
-	if err = (&multiclustercontrollers.ResourceExportReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ResourceExport")
-		os.Exit(1)
+	k8smcsCrdClient, err := k8smcsversioned.NewForConfig(k8sConfig)
+	if err != nil {
+		klog.Fatalf("Error building K8s MCS clientset: %s", err.Error())
 	}
-	if err = (&multiclustercontrollers.ResourceImportReconciler{
+	antreamcsLeaderCrdClient, err := mcsClient.NewForConfig(&leaderConfig)
+	if err != nil {
+		klog.Fatalf("Error building Antrea MCS leader clientset: %s", err.Error())
+	}
+	if member {
+		svcExportReconciler := mcscontrollers.NewServiceExportReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			kubeClient,
+			k8smcsCrdClient,
+			antreamcsLeaderCrdClient)
+		if err = svcExportReconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ServiceExport")
+			os.Exit(1)
+		}
+	}
+
+	if leader {
+		antreamcsLocalCrdClient, err := mcsClient.NewForConfig(k8sConfig)
+		if err != nil {
+			klog.Fatalf("Error building Antrea MCS leader clientset: %s", err.Error())
+		}
+		if err = (&mcscontrollers.ResourceExportReconciler{
+			Client:             mgr.GetClient(),
+			Scheme:             mgr.GetScheme(),
+			AntreamcsCrdClient: antreamcsLocalCrdClient,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ResourceExport")
+			os.Exit(1)
+		}
+	}
+
+	if err = (&mcscontrollers.ResourceImportReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ResourceImport")
 		os.Exit(1)
 	}
-	if err = (&multiclusterv1alpha1.ResourceImport{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&mcsv1alpha1.ResourceImport{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ResourceImport")
 		os.Exit(1)
 	}
-	if err = (&multiclusterv1alpha1.ResourceExport{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&mcsv1alpha1.ResourceExport{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ResourceExport")
 		os.Exit(1)
 	}

--- a/multicluster/main.go
+++ b/multicluster/main.go
@@ -226,11 +226,12 @@ func main() {
 		if err != nil {
 			klog.Fatalf("Error building Antrea MCS leader clientset: %s", err.Error())
 		}
-		if err = (&mcscontrollers.ResourceExportReconciler{
-			Client:             mgr.GetClient(),
-			Scheme:             mgr.GetScheme(),
-			AntreamcsCrdClient: antreamcsLocalCrdClient,
-		}).SetupWithManager(mgr); err != nil {
+		resExportReconciler := mcscontrollers.NewResourceExportReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			antreamcsLocalCrdClient,
+		)
+		if err = resExportReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ResourceExport")
 			os.Exit(1)
 		}


### PR DESCRIPTION
resourceexport_controller will watch resourceexport event and extract service/endpoints from resourceexport and wrap
them from member clusters into one ResourceImport if source service's Namespace and Name are the same

Signed-off-by: Lan Luo <luola@vmware.com>