### PR TITLE
Common area

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.6.0
 	github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 // indirect
+	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.19.5
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
@@ -46,6 +47,7 @@ require (
 	github.com/ti-mo/conntrack v0.3.0
 	github.com/vishvananda/netlink v1.1.1-0.20210510164352-d17758a128bf
 	github.com/vmware/go-ipfix v0.5.7
+	go.uber.org/multierr v1.6.0
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 	golang.org/x/mod v0.4.0
@@ -100,7 +102,6 @@ require (
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.3 // indirect
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
@@ -146,7 +147,6 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489 // indirect
 	go.opencensus.io v0.22.3 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect

--- a/multicluster/apis/multicluster/v1alpha1/clusterclaim_types.go
+++ b/multicluster/apis/multicluster/v1alpha1/clusterclaim_types.go
@@ -24,6 +24,8 @@ const (
 	// Identify this cluster.
 	WellKnownClusterClaimID = "id.k8s.io"
 	// Identify a clusterSet that this cluster is member of.
+	// TODO: change this to all lowercase when we remove the
+	// additional Name field in the ClusterClaim resource
 	WellKnownClusterClaimClusterSet = "clusterSet.k8s.io"
 )
 
@@ -34,6 +36,8 @@ const (
 type ClusterClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// TODO: Remove the name as it is already part of ObjectMeta and its
+	// confusing to have two names
 	// Name of the ClusterClaim.
 	Name string `json:"name,omitempty"`
 	// Value of the ClusterClaim.

--- a/multicluster/build/yamls/antrea-multicluster-leader-only.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-only.yml
@@ -1389,6 +1389,23 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -1584,6 +1601,32 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+  name: antrea-multicluster-memberclusterannounce-editor-role
+rules:
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1628,6 +1671,22 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-secret-viewer-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -1659,7 +1718,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller_manager_config.yaml: |-
+  controller_manager_config.yaml: |
     apiVersion: multicluster.crd.antrea.io/v1alpha1
     kind: MultiClusterConfig
     health:

--- a/multicluster/build/yamls/antrea-multicluster-member-only.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member-only.yml
@@ -1389,6 +1389,23 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -1584,6 +1601,32 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+  name: antrea-multicluster-memberclusterannounce-editor-role
+rules:
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1628,6 +1671,22 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-secret-viewer-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -1659,7 +1718,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller_manager_config.yaml: |-
+  controller_manager_config.yaml: |
     apiVersion: multicluster.crd.antrea.io/v1alpha1
     kind: MultiClusterConfig
     health:

--- a/multicluster/build/yamls/antrea-multicluster.yml
+++ b/multicluster/build/yamls/antrea-multicluster.yml
@@ -1389,6 +1389,23 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -1584,6 +1601,32 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+  name: antrea-multicluster-memberclusterannounce-editor-role
+rules:
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1628,6 +1671,22 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-secret-viewer-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -1659,7 +1718,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller_manager_config.yaml: |-
+  controller_manager_config.yaml: |
     apiVersion: multicluster.crd.antrea.io/v1alpha1
     kind: MultiClusterConfig
     health:

--- a/multicluster/config/leader-multi-cluster.yaml
+++ b/multicluster/config/leader-multi-cluster.yaml
@@ -1,0 +1,2302 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: clusterclaims.multicluster.crd.antrea.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: antrea-multicluster-webhook-service
+          namespace: kube-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ClusterClaim
+    listKind: ClusterClaimList
+    plural: clusterclaims
+    singular: clusterclaim
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClaim is the Schema for the clusterclaims API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          name:
+            description: Name of the ClusterClaim.
+            type: string
+          value:
+            description: Value of the ClusterClaim.
+            type: string
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: clustersets.multicluster.crd.antrea.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: antrea-multicluster-webhook-service
+          namespace: kube-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ClusterSet
+    listKind: ClusterSetList
+    plural: clustersets
+    singular: clusterset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterSet is the Schema for the clustersets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSetSpec defines the desired state of ClusterSet.
+            properties:
+              leaders:
+                description: Leaders include leader clusters known to the member clusters.
+                items:
+                  description: MemberCluster defines member cluster information.
+                  properties:
+                    clusterID:
+                      description: Identify member cluster in ClusterSet.
+                      type: string
+                    secret:
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
+                      type: string
+                    server:
+                      description: API server of the destination cluster.
+                      type: string
+                    serviceAccount:
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
+                      type: string
+                  type: object
+                type: array
+              members:
+                description: Members include member clusters known to the leader clusters.
+                  Used in leader cluster.
+                items:
+                  description: MemberCluster defines member cluster information.
+                  properties:
+                    clusterID:
+                      description: Identify member cluster in ClusterSet.
+                      type: string
+                    secret:
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
+                      type: string
+                    server:
+                      description: API server of the destination cluster.
+                      type: string
+                    serviceAccount:
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
+                      type: string
+                  type: object
+                type: array
+              namespace:
+                description: Namespace to connect to in leader clusters. Used in member
+                  cluster.
+                type: string
+            type: object
+          status:
+            description: ClusterSetStatus defines the observed state of ClusterSet.
+            properties:
+              clusterStatuses:
+                description: The status of individual member clusters.
+                items:
+                  properties:
+                    clusterID:
+                      description: ClusterID is the unique identifier of this cluster.
+                      type: string
+                    conditions:
+                      items:
+                        description: ClusterCondition indicates the readiness condition
+                          of a cluster.
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transited from one
+                              status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details
+                              about the transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              conditions:
+                description: The overall condition of the cluster set.
+                items:
+                  description: ClusterSetCondition indicates the readiness condition
+                    of the clusterSet.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transited from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
+              readyClusters:
+                description: Total number of clusters ready and connected.
+                format: int32
+                type: integer
+              totalClusters:
+                description: Total number of member clusters configured in the set.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: memberclusterannounces.multicluster.crd.antrea.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: antrea-multicluster-webhook-service
+          namespace: kube-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: multicluster.crd.antrea.io
+  names:
+    kind: MemberClusterAnnounce
+    listKind: MemberClusterAnnounceList
+    plural: memberclusterannounces
+    singular: memberclusterannounce
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MemberClusterAnnounce is the Schema for the memberclusterannounces
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          clusterID:
+            description: ClusterID of the member cluster.
+            type: string
+          clusterSetID:
+            description: ClusterSet this member belongs to.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          leaderClusterID:
+            description: Leader cluster this member has selected.
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: resourceexportfilters.multicluster.crd.antrea.io
+spec:
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ResourceExportFilter
+    listKind: ResourceExportFilterList
+    plural: resourceexportfilters
+    singular: resourceexportfilter
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceExportFilter is the Schema for the ResourceExportFilters
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceExportFilterSpec defines the desired state of ResourceExportFilter
+            type: object
+          status:
+            description: ResourceExportFilterStatus defines the observed state of
+              ResourceExportFilter
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: resourceexports.multicluster.crd.antrea.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: antrea-multicluster-webhook-service
+          namespace: kube-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ResourceExport
+    listKind: ResourceExportList
+    plural: resourceexports
+    singular: resourceexport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceExport is the Schema for the resourceexports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceExportSpec defines the desired state of ResourceExport
+            properties:
+              clusterID:
+                description: ClusterID specifies the member cluster this resource
+                  exported from.
+                type: string
+              endpoints:
+                description: If exported resource is EndPoints.
+                properties:
+                  subsets:
+                    items:
+                      description: 'EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
+                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
+                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
+                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
+                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      properties:
+                        addresses:
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        notReadyAddresses:
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        ports:
+                          description: Port numbers available on the related IP addresses.
+                          items:
+                            description: EndpointPort is a tuple that describes a
+                              single port.
+                            properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. This is
+                                  a beta field that is guarded by the ServiceAppProtocol
+                                  feature gate and enabled by default.
+                                type: string
+                              name:
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
+                                type: string
+                              port:
+                                description: The port number of the endpoint.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              externalentity:
+                description: If exported resource is ExternalEntity.
+                properties:
+                  externalentityspec:
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
+                    properties:
+                      endpoints:
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
+                        items:
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
+                          properties:
+                            ip:
+                              description: IP associated with this endpoint.
+                              type: string
+                            name:
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
+                              type: string
+                          type: object
+                        type: array
+                      externalNode:
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
+                        type: string
+                      ports:
+                        description: Ports maintain the list of named ports.
+                        items:
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
+                          properties:
+                            name:
+                              description: Name associated with the Port.
+                              type: string
+                            port:
+                              description: The port on the given protocol.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              kind:
+                description: Kind of exported resource.
+                type: string
+              name:
+                description: Name of exported resource.
+                type: string
+              namespace:
+                description: Namespace of exported resource.
+                type: string
+              raw:
+                description: If exported resource Kind is unknown.
+                properties:
+                  data:
+                    format: byte
+                    type: string
+                type: object
+              service:
+                description: If exported resource is Service.
+                properties:
+                  serviceSpec:
+                    description: ServiceSpec describes the attributes that a user
+                      creates on a service.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with type LoadBalancer.  Default
+                          is "true". It may be set to "false" if the cluster load-balancer
+                          does not rely on NodePorts. allocateLoadBalancerNodePorts
+                          may only be set for services with type LoadBalancer and
+                          will be cleared if the type is changed to any other type.
+                          This field is alpha-level and is only honored by servers
+                          that enable the ServiceLBNodePortControl feature.
+                        type: boolean
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly. If an address is specified
+                          manually, is in-range (as per system configuration), and
+                          is not in use, it will be allocated to the service; otherwise
+                          creation of the service will fail. This field may not be
+                          changed through updates unless the type field is also being
+                          changed to ExternalName (which requires this field to be
+                          blank) or the type field is being changed from ExternalName
+                          (in which case this field may optionally be specified, as
+                          describe above).  Valid values are "None", empty string
+                          (""), or a valid IP address. Setting this to "None" makes
+                          a "headless service" (no virtual IP), which is useful when
+                          direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort,
+                          and LoadBalancer. If this field is specified when creating
+                          a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      clusterIPs:
+                        description: "ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.  If
+                          an address is specified manually, is in-range (as per system
+                          configuration), and is not in use, it will be allocated
+                          to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the
+                          type field is also being changed to ExternalName (which
+                          requires this field to be empty) or the type field is being
+                          changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values
+                          are \"None\", empty string (\"\"), or a valid IP address.
+                          \ Setting this to \"None\" makes a \"headless service\"
+                          (no virtual IP), which is useful when direct endpoint connections
+                          are preferred and proxying is not required.  Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. If this
+                          field is specified when creating a Service of type ExternalName,
+                          creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified,
+                          it will be initialized from the clusterIP field.  If this
+                          field is specified, clients must ensure that clusterIPs[0]
+                          and clusterIP have the same value. \n Unless the \"IPv6DualStack\"
+                          feature gate is enabled, this field is limited to one value,
+                          which must be the same as the clusterIP field.  If the feature
+                          gate is enabled, this field may hold a maximum of two entries
+                          (dual-stack IPs, in either order).  These IPs must correspond
+                          to the values of the ipFamilies field. Both clusterIPs and
+                          ipFamilies are governed by the ipFamilyPolicy field. More
+                          info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this service (e.g.
+                          a DNS CNAME record). No proxying will be involved.  Must
+                          be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                          and requires `type` to be "ExternalName".
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. This only applies when type is
+                          set to LoadBalancer and externalTrafficPolicy is set to
+                          Local. If a value is specified, is in-range, and is not
+                          in use, it will be used.  If not specified, a value will
+                          be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints
+                          for this service or not.  If this field is specified when
+                          creating a Service which does not need it, creation will
+                          fail. This field will be wiped when updating a Service to
+                          no longer need it (e.g. changing type).
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or node-local
+                          endpoints only. "Cluster" routes internal traffic to a Service
+                          to all endpoints. "Local" routes traffic to node-local endpoints
+                          only, traffic is dropped if no node-local endpoints are
+                          ready. The default value is "Cluster".
+                        type: string
+                      ipFamilies:
+                        description: "IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                          feature gate.  This field is usually assigned automatically
+                          based on cluster configuration and the ipFamilyPolicy field.
+                          If this field is specified manually, the requested family
+                          is available in the cluster, and ipFamilyPolicy allows it,
+                          it will be used; otherwise creation of the service will
+                          fail.  This field is conditionally mutable: it allows for
+                          adding or removing a secondary IP family, but it does not
+                          allow changing the primary IP family of the Service.  Valid
+                          values are \"IPv4\" and \"IPv6\".  This field only applies
+                          to Services of types ClusterIP, NodePort, and LoadBalancer,
+                          and does apply to \"headless\" services.  This field will
+                          be wiped when updating a Service to type ExternalName. \n
+                          This field may hold a maximum of two entries (dual-stack
+                          families, in either order).  These families must correspond
+                          to the values of the clusterIPs field, if specified. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                          field."
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6). This type is used to express the family of an IP
+                            expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service, and is gated by the
+                          "IPv6DualStack" feature gate.  If there is no value provided,
+                          then this field will be set to SingleStack. Services can
+                          be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail). The ipFamilies and clusterIPs fields depend on the
+                          value of this field.  This field will be wiped when updating
+                          a service to type ExternalName.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to. If specified, the
+                          value of this field must be a label-style identifier, with
+                          an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                          Unprefixed names are reserved for end-users. This field
+                          can only be set when the Service type is 'LoadBalancer'.
+                          If not set, the default load balancer implementation is
+                          used, today this is typically done through the cloud provider
+                          integration, but should apply for any default implementation.
+                          If set, it is assumed that a load balancer implementation
+                          is watching for Services with a matching class. Any default
+                          load balancer implementation (e.g. cloud providers) should
+                          ignore Services that set this field. This field can only
+                          be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped
+                          when a service is updated to a non 'LoadBalancer' type.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. This is a beta
+                                field that is guarded by the ServiceAppProtocol feature
+                                gate and enabled by default.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.  Usually
+                                assigned by the system. If a value is specified, in-range,
+                                and not in use it will be used, otherwise the operation
+                                will fail.  If not specified, a port will be allocated
+                                if this Service requires one.  If this field is specified
+                                when creating a Service which does not need it, creation
+                                will fail. This field will be wiped when updating
+                                a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should disregard
+                          any indications of ready/not-ready. The primary use case
+                          for setting this field is for a StatefulSet's Headless Service
+                          to propagate SRV DNS records for its Pods for the purpose
+                          of peer discovery. The Kubernetes controllers that generate
+                          Endpoints and EndpointSlice resources for Services interpret
+                          this to mean that all endpoints are considered "ready" even
+                          if the Pods themselves are not. Agents which consume only
+                          Kubernetes generated endpoints through the Endpoints or
+                          EndpointSlice resources can safely assume this behavior.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      topologyKeys:
+                        description: topologyKeys is a preference-order list of topology
+                          keys which implementations of services should use to preferentially
+                          sort endpoints when accessing this Service, it can not be
+                          used at the same time as externalTrafficPolicy=Local. Topology
+                          keys must be valid label keys and at most 16 keys may be
+                          specified. Endpoints are chosen based on the first topology
+                          key with available backends. If this field is specified
+                          and all entries have no backends that match the topology
+                          of the client, the service has no backends for that client
+                          and connections should fail. The special value "*" may be
+                          used to mean "any topology". This catch-all value, if used,
+                          only makes sense as the last value in the list. If this
+                          is not specified or empty, no topology constraints will
+                          be applied. This field is alpha-level and is only honored
+                          by servers that enable the ServiceTopology feature. This
+                          field is deprecated and will be removed in a future version.
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                          IP address for load-balancing to endpoints. Endpoints are
+                          determined by the selector or if that is not specified,
+                          by manual construction of an Endpoints object or EndpointSlice
+                          objects. If clusterIP is "None", no virtual IP is allocated
+                          and the endpoints are published as a set of endpoints rather
+                          than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                          a port on every node which routes to the same endpoints
+                          as the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the same endpoints as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ResourceExportStatus defines the observed state of ResourceExport
+            properties:
+              conditions:
+                items:
+                  description: ResourceExportCondition indicates the readiness condition
+                    of the ResourceExport
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transited from one status
+                        to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: resourceimportfilters.multicluster.crd.antrea.io
+spec:
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ResourceImportFilter
+    listKind: ResourceImportFilterList
+    plural: resourceimportfilters
+    singular: resourceimportfilter
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceImportFilter is the Schema for the ResourceImportFilters
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceImportFilterSpec defines the desired state of ResourceImportFilter
+            type: object
+          status:
+            description: ResourceImportFilterStatus defines the observed state of
+              ResourceImportFilter
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: resourceimports.multicluster.crd.antrea.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: antrea-multicluster-webhook-service
+          namespace: kube-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ResourceImport
+    listKind: ResourceImportList
+    plural: resourceimports
+    singular: resourceimport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceImport is the Schema for the resourceimports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceImportSpec defines the desired state of ResourceImport
+            properties:
+              clusterID:
+                description: ClusterIDs specifies the member clusters this resource
+                  to import to. When not specified, import to all member clusters.
+                items:
+                  type: string
+                type: array
+              endpoints:
+                description: If imported resource is EndPoints.
+                properties:
+                  subsets:
+                    items:
+                      description: 'EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
+                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
+                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
+                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
+                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      properties:
+                        addresses:
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        notReadyAddresses:
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        ports:
+                          description: Port numbers available on the related IP addresses.
+                          items:
+                            description: EndpointPort is a tuple that describes a
+                              single port.
+                            properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. This is
+                                  a beta field that is guarded by the ServiceAppProtocol
+                                  feature gate and enabled by default.
+                                type: string
+                              name:
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
+                                type: string
+                              port:
+                                description: The port number of the endpoint.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              externalentity:
+                description: If imported resource is ExternalEntity.
+                properties:
+                  externalentityspec:
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
+                    properties:
+                      endpoints:
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
+                        items:
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
+                          properties:
+                            ip:
+                              description: IP associated with this endpoint.
+                              type: string
+                            name:
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
+                              type: string
+                          type: object
+                        type: array
+                      externalNode:
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
+                        type: string
+                      ports:
+                        description: Ports maintain the list of named ports.
+                        items:
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
+                          properties:
+                            name:
+                              description: Name associated with the Port.
+                              type: string
+                            port:
+                              description: The port on the given protocol.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              kind:
+                description: Kind of imported resource.
+                type: string
+              name:
+                description: Name of imported resource.
+                type: string
+              namespace:
+                description: Namespace of imported resource.
+                type: string
+              raw:
+                description: 'If imported resource is ANP. TODO: ANP uses float64
+                  as priority.  Type float64 is discouraged by k8s, and is not supported
+                  by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec
+                  `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
+                properties:
+                  data:
+                    format: byte
+                    type: string
+                type: object
+              serviceImport:
+                description: If imported resource is ServiceImport.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    type: object
+                  spec:
+                    description: spec defines the behavior of a ServiceImport.
+                    properties:
+                      ips:
+                        description: ip will be used as the VIP for this service when
+                          type is ClusterSetIP.
+                        items:
+                          type: string
+                        maxItems: 1
+                        type: array
+                      ports:
+                        items:
+                          description: ServicePort represents the port on which the
+                            service is exposed
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. Field can be
+                                enabled with ServiceAppProtocol feature gate.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. Ignored when
+                          type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains session affinity
+                          configuration.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: type defines the type of this service. Must be
+                          ClusterSetIP or Headless.
+                        enum:
+                        - ClusterSetIP
+                        - Headless
+                        type: string
+                    required:
+                    - ports
+                    - type
+                    type: object
+                  status:
+                    description: status contains information about the exported services
+                      that form the multi-cluster service referenced by this ServiceImport.
+                    properties:
+                      clusters:
+                        description: clusters is the list of exporting clusters from
+                          which this service was derived.
+                        items:
+                          description: ClusterStatus contains service configuration
+                            mapped to a specific source cluster
+                          properties:
+                            cluster:
+                              description: cluster is the name of the exporting cluster.
+                                Must be a valid RFC-1123 DNS label.
+                              type: string
+                          required:
+                          - cluster
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - cluster
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ResourceImportStatus defines the observed state of ResourceImport
+            properties:
+              clusterStatuses:
+                items:
+                  description: ResourceImportClusterStatus indicates the readiness
+                    status of the ResourceImport in clusters
+                  properties:
+                    clusterID:
+                      description: ClusterID is the unique identifier of this cluster.
+                      type: string
+                    conditions:
+                      items:
+                        description: ResourceImportCondition indicates the condition
+                          of the ResourceImport in a cluster
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transited from one
+                              status to another
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details
+                              about the transition
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: antrea-multicluster-leader-election-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: antrea-multicluster-controller-role
+rules:
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clusterclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clusterclaims/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clusterclaims/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexportfilters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexportfilters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexportfilters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimportfilters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimportfilters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimportfilters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: antrea-multicluster-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: antrea-multicluster-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: antrea-multicluster-secret-viewer-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: antrea-multicluster-leader-election-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: antrea-multicluster-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-multicluster-controller-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: antrea-multicluster-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-multicluster-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: antrea-multicluster-secret-viewer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-secret-viewer-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: antrea-multicluster-controller
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 6536456a.crd.antrea.io
+    isLeader: true
+kind: ConfigMap
+metadata:
+  name: antrea-multicluster-manager-config
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: antrea-multicluster-controller
+  name: antrea-multicluster-controller-metrics-service
+  namespace: kube-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: antrea-multicluster-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: antrea-multicluster-webhook-service
+  namespace: kube-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: antrea-multicluster-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: antrea-multicluster-controller
+  name: antrea-multicluster-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: antrea-multicluster-controller
+  template:
+    metadata:
+      labels:
+        control-plane: antrea-multicluster-controller
+    spec:
+      containers:
+      - args:
+        - --config=controller_manager_config.yaml
+        - --is-mcs-leader
+        command:
+        - /manager
+        image: antrea/antrea-multicluster-controller:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /controller_manager_config.yaml
+          name: manager-config
+          subPath: controller_manager_config.yaml
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: antrea-multicluster-controller
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+      - configMap:
+          name: antrea-multicluster-manager-config
+        name: manager-config
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: antrea-multicluster-serving-cert
+  namespace: kube-system
+spec:
+  dnsNames:
+  - antrea-multicluster-webhook-service.kube-system.svc
+  - antrea-multicluster-webhook-service.kube-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: antrea-multicluster-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: antrea-multicluster-selfsigned-issuer
+  namespace: kube-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+  name: antrea-multicluster-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
+  failurePolicy: Fail
+  name: mclusterclaim.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterset
+  failurePolicy: Fail
+  name: mclusterset.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustersets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /mutate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
+  failurePolicy: Fail
+  name: mmemberclusterannounce.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - memberclusterannounces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport
+  failurePolicy: Fail
+  name: mresourceexport.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourceexports
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceimport
+  failurePolicy: Fail
+  name: mresourceimport.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourceimports
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/antrea-multicluster-serving-cert
+  name: antrea-multicluster-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
+  failurePolicy: Fail
+  name: vclusterclaim.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
+  failurePolicy: Fail
+  name: vclusterset.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustersets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
+  failurePolicy: Fail
+  name: vmemberclusterannounce.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - memberclusterannounces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceexport
+  failurePolicy: Fail
+  name: vresourceexport.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourceexports
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-multicluster-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceimport
+  failurePolicy: Fail
+  name: vresourceimport.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourceimports
+  sideEffects: None

--- a/multicluster/config/multi-cluster.yaml
+++ b/multicluster/config/multi-cluster.yaml
@@ -1389,6 +1389,23 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -1584,6 +1601,32 @@ kind: ClusterRole
 metadata:
   labels:
     app: antrea
+  name: antrea-multicluster-memberclusterannounce-editor-role
+rules:
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
   name: antrea-multicluster-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1622,6 +1665,22 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: antrea-multicluster-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-secret-viewer-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-secret-viewer-role
 subjects:
 - kind: ServiceAccount
   name: antrea-multicluster-controller

--- a/multicluster/config/rbac/kustomization.yaml
+++ b/multicluster/config/rbac/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- secret_viewer_role.yaml
+- secret_viewer_role_binding.yaml
+- memberclusterannounce_editor_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/multicluster/config/rbac/secret_viewer_role.yaml
+++ b/multicluster/config/rbac/secret_viewer_role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-viewer-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/multicluster/config/rbac/secret_viewer_role_binding.yaml
+++ b/multicluster/config/rbac/secret_viewer_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-viewer-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-multicluster-secret-viewer-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-multicluster-controller
+  namespace: kube-system

--- a/multicluster/config/samples/multicluster_v1alpha1_clusterclaim.yaml
+++ b/multicluster/config/samples/multicluster_v1alpha1_clusterclaim.yaml
@@ -1,7 +1,15 @@
 apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: ClusterClaim
 metadata:
-  name: clusterclaim-sample
-spec:
-  # Add fields here
-  foo: bar
+  name: leaderclusterid
+  namespace: member-ns-one
+name: id.k8s.io
+value: test-leader
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: leaderclustersetid
+  namespace: member-ns-one
+name: clusterSet.k8s.io
+value: test-clusterset

--- a/multicluster/config/samples/multicluster_v1alpha1_clusterset.yaml
+++ b/multicluster/config/samples/multicluster_v1alpha1_clusterset.yaml
@@ -1,7 +1,18 @@
 apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: ClusterSet
 metadata:
-  name: clusterset-sample
+    name: clusterset-sample
+    namespace: kube-system
 spec:
-  # Add fields here
-  foo: bar
+    # Sample to be applied on a member cluster
+    leaders:
+      - clusterID: test-leader
+        secret: "clusterset-member-1-token-bccfl"
+        server: "https://172.18.0.2:6443"
+        # serviceAccount: "" # This is NA
+    members:
+      - clusterID: test-member-1
+        # secret: "" # This is NA
+        # server: "" # This is NA
+        # serviceAccount: "" # This is NA
+    namespace: member-ns-one

--- a/multicluster/controllers/multicluster/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/clusterset_controller.go
@@ -18,38 +18,94 @@ package multicluster
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
+	"github.com/go-logr/logr"
+	"go.uber.org/multierr"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+	"antrea.io/antrea/multicluster/controllers/multicluster/internal"
 )
 
 // ClusterSetReconciler reconciles a ClusterSet object
+// There will be one controller running in each namespace of the leader for multiple cluster-set support
+// so each controller will only be handling a single cluster set in the given namespace.
+// TODO: Split the reconciler for member and leader to avoid if checks. In case a cluster is both a
+//       member and a leader, 2 instances of the controller will need to be run, one as a leader
+//		 the second as a member.
 type ClusterSetReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	mutex    sync.Mutex
+	Scheme   *runtime.Scheme
+	Log      logr.Logger
+	IsLeader bool
+
+	clusterSetConfig *multiclusterv1alpha1.ClusterSet
+	clusterSetID     common.ClusterSetID
+	clusterID        common.ClusterID
+
+	// These fields are only applicable on leader cluster
+	LocalClusterManager internal.LocalClusterManager
+
+	// These fields are only applicable on member cluster
+	RemoteClusterManager internal.RemoteClusterManager
 }
 
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=clustersets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=clustersets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=multicluster.crd.antrea.io,resources=clustersets/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ClusterSet object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
+// Reconcile ClusterSet CRD changes
 func (r *ClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	_ = r.Log.WithValues("ClusterSet", req.Namespace)
 
-	// your logic here
+	clusterSet := &multiclusterv1alpha1.ClusterSet{}
+	err := r.Get(ctx, req.NamespacedName, clusterSet)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		// if errors.IsNotFound(err)
+		r.Log.Info("Received ClusterSet delete", "config", clusterSet, "leader", r.IsLeader)
+		if !r.IsLeader {
+			if err := r.RemoteClusterManager.Stop(); err != nil {
+				return ctrl.Result{}, err
+			}
+		} else {
+			if err := r.LocalClusterManager.Stop(); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	r.Log.Info("Received ClusterSet add/update", "config", clusterSet, "leader", r.IsLeader)
+
+	// Handle create or update
+	// If create
+	//   if leader, make sure the local cluster claim is part of the leader config
+	//   if not leader, make sure the local cluster claim is part of the member config
+	if err = r.validateLocalClusterClaim(clusterSet); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// if update,
+	//    if leader - nothing to do in inbound mode
+	//    if member - if leaders have changed handle accordingly, else nothing to do.
+	if !r.IsLeader {
+		err = r.updateMultiClusterSetOnMemberCluster(clusterSet)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		r.createOrUpdateMultiClusterSetOnLeaderCluster(clusterSet)
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -59,4 +115,173 @@ func (r *ClusterSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multiclusterv1alpha1.ClusterSet{}).
 		Complete(r)
+}
+
+func (r *ClusterSetReconciler) validateLocalClusterClaim(clusterSet *multiclusterv1alpha1.ClusterSet) error {
+	// read the cluster claim in the cluster
+	configNamespace := clusterSet.GetNamespace()
+
+	clusterClaimList := &multiclusterv1alpha1.ClusterClaimList{}
+	r.Log.Info("Validating cluster claim in", "namespace", configNamespace)
+	if err := r.List(context.TODO(), clusterClaimList, client.InNamespace(configNamespace)); err != nil {
+		return err
+	}
+	if len(clusterClaimList.Items) == 0 {
+		return fmt.Errorf("cluster claim is not configured for the cluster")
+	}
+
+	var clusterSetClaimID string
+	wellKnownClusterSetClaimIDExist := false
+	var clusterClaimID string
+	wellKnownClusterClaimIDExist := false
+	for _, clusterClaim := range clusterClaimList.Items {
+		r.Log.Info("Processing clusterclaim", "name", clusterClaim.Name, "value", clusterClaim.Value)
+		if clusterClaim.Name == multiclusterv1alpha1.WellKnownClusterClaimClusterSet {
+			wellKnownClusterSetClaimIDExist = true
+			clusterSetClaimID = clusterClaim.Value
+		} else if clusterClaim.Name == multiclusterv1alpha1.WellKnownClusterClaimID {
+			wellKnownClusterClaimIDExist = true
+			clusterClaimID = clusterClaim.Value
+		}
+	}
+
+	if !wellKnownClusterSetClaimIDExist {
+		return fmt.Errorf("clusterset claim ID not configured for the cluster")
+	}
+
+	if !wellKnownClusterClaimIDExist {
+		return fmt.Errorf("cluster claim ID not configured for the cluster")
+	}
+
+	configExists := false
+	if r.IsLeader {
+		//  validate the namespace is the same
+		if clusterSet.Spec.Namespace != clusterSet.GetNamespace() {
+			return fmt.Errorf("cluster set namespace " + clusterSet.Spec.Namespace + " is different from " +
+				clusterSet.GetNamespace())
+		}
+		for _, leader := range clusterSet.Spec.Leaders {
+			if clusterClaimID == leader.ClusterID {
+				configExists = true
+				break
+			}
+		}
+		if !configExists {
+			return fmt.Errorf("cluster not defined as leader in cluster set")
+		}
+	} else {
+		for _, member := range clusterSet.Spec.Members {
+			if clusterClaimID == member.ClusterID {
+				configExists = true
+				break
+			}
+		}
+		if !configExists {
+			return fmt.Errorf("cluster not defined as member in cluster set")
+		}
+	}
+
+	r.clusterID = common.ClusterID(clusterClaimID)
+	r.clusterSetID = common.ClusterSetID(clusterSetClaimID)
+	r.clusterSetConfig = clusterSet.DeepCopy()
+
+	return nil
+}
+
+func (r *ClusterSetReconciler) createOrUpdateMultiClusterSetOnLeaderCluster(clusterSet *multiclusterv1alpha1.ClusterSet) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.LocalClusterManager == nil {
+		// TODO: refer to Antrea code to provide a method like NewClusterSetReconciler to do initialization in one place?
+		// antrea/multicluster/controllers/multicluster/resourceexport_controller.go and
+		r.LocalClusterManager = internal.NewLocalClusterManager(r.Client, r.clusterID, clusterSet.GetNamespace(), r.Log)
+	}
+}
+
+func (r *ClusterSetReconciler) updateMultiClusterSetOnMemberCluster(clusterSet *multiclusterv1alpha1.ClusterSet) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.RemoteClusterManager == nil {
+		r.RemoteClusterManager = internal.NewRemoteClusterManager(r.clusterSetID, r.Log, r.clusterID)
+		go func() {
+			r.Log.Info("Starting remote cluster manager", "clusterSetID", r.clusterSetID)
+			var err error
+			err = r.RemoteClusterManager.Start()
+			if err != nil {
+				r.Log.Error(err, "Error starting remote cluster manager")
+			}
+			r.mutex.Lock()
+			r.RemoteClusterManager = nil
+			r.clusterSetID = common.INVALID_CLUSTER_SET_ID
+			r.clusterID = common.INVALID_CLUSTER_ID
+			r.clusterSetConfig = nil
+			r.mutex.Unlock()
+		}()
+	}
+
+	currentLeaders := r.RemoteClusterManager.GetRemoteClusters()
+	newLeaders := clusterSet.Spec.Leaders
+
+	var addedLeaders []*multiclusterv1alpha1.MemberCluster
+	var removedLeaders map[common.ClusterID]internal.RemoteCluster
+
+	for _, leader := range newLeaders {
+		leaderID := common.ClusterID(leader.ClusterID)
+		_, found := currentLeaders[leaderID]
+		if !found {
+			addedLeaders = append(addedLeaders, leader.DeepCopy())
+		} else {
+			// In the end currentLeaders will only have removed leaders
+			delete(currentLeaders, leaderID)
+		}
+	}
+
+	ch := make(chan error)
+	var wg sync.WaitGroup
+	wg.Add(len(addedLeaders))
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	for _, addedLeader := range addedLeaders {
+		clusterID := common.ClusterID(addedLeader.ClusterID)
+		url := addedLeader.Server
+		secretName := addedLeader.Secret
+
+		r.Log.Info("creating remote cluster", "clusterID", clusterID)
+
+		go func(clusterID common.ClusterID, url string, secretName string) {
+			defer wg.Done()
+
+			_, err := internal.NewRemoteCluster(clusterID, r.clusterSetID, url, secretName, r.Scheme,
+				r.Log, r.RemoteClusterManager, clusterSet.Spec.Namespace, clusterSet.GetNamespace())
+			if err != nil {
+				r.Log.Error(err, "Unable to create remote cluster", "clusterID", clusterID)
+			} else {
+				r.Log.Info("Created", "clusterID", clusterID)
+			}
+
+			ch <- err
+		}(clusterID, url, secretName)
+	}
+
+	var err error
+	for errFromCh := range ch {
+		if errFromCh != nil {
+			r.Log.Error(errFromCh, "Received error")
+			err = multierr.Append(err, errFromCh)
+		}
+	}
+
+	removedLeaders = currentLeaders
+	for _, remoteCluster := range removedLeaders {
+		r.RemoteClusterManager.RemoveRemoteCluster(remoteCluster)
+		r.Log.Info("Deleted", "clusterID", remoteCluster.GetClusterID())
+	}
+
+	r.Log.Error(err, "Final error")
+	return err
 }

--- a/multicluster/controllers/multicluster/common/common_area.go
+++ b/multicluster/controllers/multicluster/common/common_area.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Access to common area of a cluster
+// For common area used in LocalClusterManager - this provides access to the local cluster in a given namespace
+// for common area used in RemoteCluster - this provides access to the remote cluster's namespace
+type CommonArea interface {
+	// Grant read/write to the cluster for a specific namespace
+	client.Client
+
+	// GetClusterID returns the clusterID of the cluster accessed by this common area
+	GetClusterID() ClusterID
+
+	// Get namespace backing this common area
+	GetNamespace() string
+}

--- a/multicluster/controllers/multicluster/common/types.go
+++ b/multicluster/controllers/multicluster/common/types.go
@@ -1,0 +1,9 @@
+package common
+
+type ClusterID string
+type ClusterSetID string
+
+const (
+	INVALID_CLUSTER_ID     = ClusterID("invalid")
+	INVALID_CLUSTER_SET_ID = ClusterSetID("invalid")
+)

--- a/multicluster/controllers/multicluster/internal/leader_elector.go
+++ b/multicluster/controllers/multicluster/internal/leader_elector.go
@@ -1,0 +1,105 @@
+package internal
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+)
+
+/**
+ * Lets consider a ClusterSet with 2 leader clusters and 1 member cluster
+ *      Leader1        Leader2
+ *			\         /
+ *			 \       /
+ *            -------
+ *               ^
+ *               |
+ *            Member1
+ * The member cluster connects to both leaders and performs Member Announce
+ * to announce itself. And all resources from the Members are written into
+ * Common Area of all Leader clusters. However resources are imported
+ * only from an elected-leader cluster.
+ *
+ * This interface performs the election to pick an elected-leader
+ * from the list of leader clusters in the ClusterSet spec.
+ *
+ * Leader Election picks an elected-leader among "connected" leaders
+ * by choosing one randomly
+ * The Member Cluster periodically writes MemberAnnounce CRD into every leader
+ * cluster and is considered "connected" if it can successfully write so.
+ * After leader election is done, the result is also used to update the
+ * spec of the MemberAnnounce CRD during the next periodic write into
+ * the leader's Common Area, so the leader knows it is the elected-leader
+ * of this member (mainly for visibility and reporting)
+ */
+type LeaderElector interface {
+	// start the leader elector, returns a cancelFunc to invoke when it must be stopped
+	StartLeaderElection() context.CancelFunc
+}
+
+func (m *remoteClusterManager) StartLeaderElection() (context.CancelFunc, error) {
+	stopCtx, stopFunc := context.WithCancel(context.Background())
+
+	// Start a Timer for every 5 seconds when leader election is
+	// performed, if necessary
+	ticker := time.NewTicker(5 * time.Second)
+	rand.Seed(time.Now().UnixNano())
+
+	go func() {
+		log := m.log.WithName("LeaderElector")
+		log.Info("Starting leader election")
+		for {
+			select {
+			case <-stopCtx.Done():
+				log.Info("Stopping leader election")
+				return
+			case <-ticker.C:
+				// 5 second timer has gone off, check if election must be done
+				if !m.needElection {
+					if m.electedLeaderCluster != nil && !m.electedLeaderCluster.IsConnected() {
+						log.Info("Leader disconnected", "leader", m.electedLeaderCluster.GetClusterID())
+						m.electedLeaderCluster = nil
+					}
+					if m.electedLeaderCluster == nil {
+						// do we have any member that is connected?
+						for _, cluster := range m.remoteClusters {
+							if cluster.IsConnected() {
+								m.needElection = true
+							}
+						}
+					}
+				}
+				if m.needElection {
+					m.DoLeaderElection()
+				}
+			}
+		}
+	}()
+
+	return stopFunc, nil
+}
+
+func (m *remoteClusterManager) DoLeaderElection() {
+	log := m.log.WithName("LeaderElector")
+
+	// We have written member announce at least once to all remote clusters.
+	// Pick one randomly if it is connected
+	var connectedClusterIDs []common.ClusterID
+	for _, cluster := range m.remoteClusters {
+		if cluster.IsConnected() {
+			connectedClusterIDs = append(connectedClusterIDs, cluster.GetClusterID())
+		}
+	}
+	if len(connectedClusterIDs) > 0 {
+		electedLeaderIndex := rand.Intn(len(connectedClusterIDs))
+		// election complete
+		electedLeaderClusterID := connectedClusterIDs[electedLeaderIndex]
+		m.electedLeaderCluster = m.remoteClusters[electedLeaderClusterID]
+		m.needElection = false
+		log.Info("Election completed", "leader", electedLeaderClusterID)
+		return
+	}
+	// couldnt elect a leader, will try next round
+}

--- a/multicluster/controllers/multicluster/internal/local_cluster_manager.go
+++ b/multicluster/controllers/multicluster/internal/local_cluster_manager.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+)
+
+/**
+ *  This file contains implementation to manage access to common area in the local cluster backed by a namespace
+ */
+
+type LocalClusterManager interface {
+	// Access to write into the common area of the local cluster
+	// Access to read is likely not needed as the reconciler already is setup to notify changes
+	common.CommonArea
+
+	// Start the local cluster manager and block on a go routine
+	Start() error
+
+	// cleanup any state and Stop the local cluster manager
+	Stop() error
+}
+
+type localClusterManager struct {
+	client.Client
+
+	log logr.Logger
+	// this is the local cluster ID
+	clusterID common.ClusterID
+	// namespace for the cluster manager to operate in, same as the
+	// namespace in which the cluster set is defined
+	namespace string
+	// Function to stop this manager
+	stopFunc context.CancelFunc
+}
+
+func NewLocalClusterManager(client client.Client, clusterID common.ClusterID, namespace string, log logr.Logger) LocalClusterManager {
+	return &localClusterManager{
+		Client:    client,
+		log:       log.WithName("LocalClusterManager"),
+		clusterID: clusterID,
+		namespace: namespace,
+	}
+}
+
+/**
+ *  LocalClusterManager implementation
+ */
+
+func (i *localClusterManager) Start() error {
+	stopCtx, stopFunc := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-stopCtx.Done():
+				return
+			}
+		}
+	}()
+
+	i.stopFunc = stopFunc
+	return nil
+}
+
+func (i *localClusterManager) Stop() error {
+	if i.stopFunc != nil {
+		i.stopFunc()
+	}
+	return nil
+}
+
+/**
+ *  CommonArea implementation
+ */
+
+// GetClusterID returns the clusterID of the cluster accessed by this common area
+func (i *localClusterManager) GetClusterID() common.ClusterID {
+	return i.clusterID
+}
+
+// Get namespace backing this common area
+func (i *localClusterManager) GetNamespace() string {
+	return i.namespace
+}

--- a/multicluster/controllers/multicluster/internal/remote_cluster.go
+++ b/multicluster/controllers/multicluster/internal/remote_cluster.go
@@ -1,0 +1,312 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+
+)
+
+var (
+	// Use a raw client to get member cluster secrets from antrea-plus-system only.
+	secretClient client.Client
+	// multiple remote clusters can be created concurrently, need a lock to synchronize creation of secretClient
+	mutex sync.Mutex
+)
+
+// Abstraction to connect to a remote cluster's (i.e. the Leader Cluster) Common Area
+type RemoteCluster interface {
+	common.CommonArea
+
+	Start() (context.CancelFunc, error)
+
+	Stop() error
+
+	// tells whether the remote cluster is accessible or not
+	IsConnected() bool
+
+	// TODO: resource monitoring methods needs to be defined.
+}
+
+// This implements the commonArea interface and allows local cluster to read/write into
+// the common area of the remote cluster.
+type remoteCluster struct {
+	// client that provides read/write access into the remote cluster
+	client.Client
+
+	log logr.Logger
+
+	// manager to setup controllers for resources that need to be monitored in the remote cluster
+	ClusterManager manager.Manager
+
+	// ClusterID of this remote cluster
+	ClusterID common.ClusterID
+
+	// ClusterSetID of this remote cluster
+	ClusterSetID common.ClusterSetID
+
+	// config necessary to access the remote cluster
+	config *rest.Config
+
+	// scheme necessary to access the remote cluster
+	scheme *runtime.Scheme
+
+	// Namespace this clusterSet is associated with
+	Namespace string
+
+	// connectivity status, should it be the status?
+	connected bool
+
+	remoteClusterManager RemoteClusterManager
+
+	stopFunc context.CancelFunc
+}
+
+/**
+ * A remote cluster is a leader in the ClusterSet Spec. This creates a remoteCluster instance which will
+ * use the secret and access credentials for the leader to connect to its common area.
+ */
+func  NewRemoteCluster(clusterID common.ClusterID, clusterSetID common.ClusterSetID, url string, secretName string,
+	scheme *runtime.Scheme, log logr.Logger, remoteClusterManager RemoteClusterManager, clusterSetNamespace string,
+	configNamespace string) (common.CommonArea, error) {
+	log = log.WithName("remote-cluster-" + string(clusterID))
+	log.Info("Create remote cluster for", "cluster", clusterID)
+
+	// Secret associated with this local cluster must be copied from remote cluster to local cluster
+	// so that the secret data can be obtained.
+	// read/decode secret (get token and crt)
+	// TODO: what will be the namespace in the local cluster? use the same namespace where cluster set is configured
+	crtData, token, err := getSecretCACrtAndToken(configNamespace, secretName)
+	if err != nil {
+		return nil, err
+	}
+	log.Info("found", "secret", secretName)
+
+	// create manager for the member cluster
+	log.Info("Connecting", "url", url)
+	config, err := clientcmd.BuildConfigFromFlags(url, "")
+	if err != nil {
+		return nil, err
+	}
+	config.BearerToken = string(token)
+	config.CAData = crtData
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme:             scheme,
+		MetricsBindAddress: "0",
+		Logger:             log.WithName("controller-runtime"),
+	})
+	if err != nil {
+		log.V(1).Error(err, "unable to create new manager")
+		return nil, err
+	}
+
+	remoteClient, e := client.New(config, client.Options{Scheme: scheme})
+	if e != nil {
+		return nil, e
+	}
+	cluster := &remoteCluster{
+		Client:               remoteClient,
+		log:                  log,
+		ClusterManager:       mgr,
+		ClusterSetID:         clusterSetID,
+		ClusterID:            clusterID,
+		config:               config,
+		scheme:               scheme,
+		Namespace:            clusterSetNamespace,
+		connected:            false,
+		remoteClusterManager: remoteClusterManager,
+	}
+
+	remoteClusterManager.AddRemoteCluster(cluster)
+
+	return cluster, nil
+}
+
+/**
+ * When a member is added to a ClusterSet, a specific ServiceAccount is created on the
+ * leader cluster which allows the member to access into the common area. This ServiceAccount
+ * has an associated Secret which must be copied into the Member Cluster as an opaque secret.
+ * Name of this secret is part of the ClusterSet spec for this member. This method reads
+ * the Secret given by that name.
+ */
+func getSecretCACrtAndToken(namespace string, secretName string) ([]byte, []byte, error) {
+	var err error
+	mutex.Lock()
+	if secretClient == nil {
+		secretClient, err = client.New(ctrl.GetConfigOrDie(), client.Options{})
+		if err != nil {
+			mutex.Unlock()
+			return nil, nil, err
+		}
+	}
+	mutex.Unlock()
+	secretObj := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      secretName,
+	}
+	err = secretClient.Get(context.TODO(), secretNamespacedName, secretObj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caData, found := secretObj.Data[v1.ServiceAccountRootCAKey]
+	if !found {
+		return nil, nil, fmt.Errorf("ca.crt data not found in secret %v", secretName)
+	}
+
+	token, found := secretObj.Data[v1.ServiceAccountTokenKey]
+	if !found {
+		return nil, nil, fmt.Errorf("token not found in secret %v", secretName)
+	}
+
+	return caData, token, nil
+}
+
+func (r *remoteCluster) SendMemberAnnounce() error {
+	// TODO: remove this before merge to feature branch to avoid spamming logs
+	r.log.Info("Writing member announce")
+
+	memberAnnounceList := &multiclusterv1alpha1.MemberClusterAnnounceList{}
+	if err := r.List(context.TODO(), memberAnnounceList, client.InNamespace(r.GetNamespace())); err != nil {
+		return err
+	}
+	var localClusterMemberAnnounce multiclusterv1alpha1.MemberClusterAnnounce
+	localClusterMemberAnnounceExist := false
+	if len(memberAnnounceList.Items) != 0 {
+		for _, memberAnnounce := range memberAnnounceList.Items {
+			if memberAnnounce.ClusterID == string(r.remoteClusterManager.GetLocalClusterID()) {
+				localClusterMemberAnnounceExist = true
+				localClusterMemberAnnounce = memberAnnounce
+				break
+			}
+		}
+	}
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+	if localClusterMemberAnnounceExist {
+		if r.remoteClusterManager.GetElectedLeaderClusterID() != common.INVALID_CLUSTER_ID {
+			localClusterMemberAnnounce.LeaderClusterID = string(r.remoteClusterManager.GetElectedLeaderClusterID())
+		}
+
+		if localClusterMemberAnnounce.Annotations == nil {
+			localClusterMemberAnnounce.Annotations = make(map[string]string)
+		}
+		localClusterMemberAnnounce.Annotations["touch-ts"] = time.Now().String()
+		// do an update
+		if err := r.Update(ctx, &localClusterMemberAnnounce, &client.UpdateOptions{}); err != nil {
+			r.log.Error(err, "Failed to update member announce")
+			return err
+		}
+	} else {
+		// create happens first before a leader can be elected, when the create is successful
+		// it marks the connectivity status to leader election can occur
+		// Therefore the first create will not populate the leader cluster id
+		localClusterMemberAnnounce.ClusterID = string(r.remoteClusterManager.GetLocalClusterID())
+		localClusterMemberAnnounce.Name = "member-announce-from-" + string(r.remoteClusterManager.GetLocalClusterID())
+		localClusterMemberAnnounce.Namespace = r.Namespace
+		localClusterMemberAnnounce.ClusterSetID = string(r.ClusterSetID)
+		if err := r.Create(ctx, &localClusterMemberAnnounce, &client.CreateOptions{}); err != nil {
+			r.log.Error(err, "Failed to create member announce")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *remoteCluster) updateRemoteClusterStatus(connected bool, err error) {
+	if r.connected == connected {
+		return
+	}
+
+	log := r.log.WithName("MemberAnnounce")
+
+	log.Info("Updating remote cluster status", "connected", connected)
+
+	// TODO: Tolerate transient failures so we dont oscillate between connected and disconnected.
+	r.connected = connected
+}
+
+/**
+ * ---------------------------
+ * commonArea Implementation
+ * ---------------------------
+ */
+
+func (r *remoteCluster) GetClusterID() common.ClusterID {
+	return r.ClusterID
+}
+
+func (r *remoteCluster) GetNamespace() string {
+	return r.Namespace
+}
+
+/**
+ * ---------------------------
+ * RemoteCluster Implementation
+ * ---------------------------
+ */
+
+/**
+ * Once connected to the remote cluster, the start method run a timer
+ * on a go routine to periodically write MemberAnnounce CRD into the remote
+ * cluster's common area and also maintain its connectivity status to the
+ * remote cluster
+ */
+func (r *remoteCluster) Start() (context.CancelFunc, error) {
+	stopCtx, stopFunc := context.WithCancel(context.Background())
+
+	// Start a Timer for every 5 seconds
+	ticker := time.NewTicker(5 * time.Second)
+
+	go func() {
+		r.log.Info("Starting MemberAnnounce")
+		for {
+			select {
+			case <-stopCtx.Done():
+				r.log.Info("Stopping MemberAnnounce")
+				return
+			case <-ticker.C:
+				// do member announce
+				if err := r.SendMemberAnnounce(); err != nil {
+					// will be tried again
+					r.log.Error(err, "error writing member announce")
+					r.updateRemoteClusterStatus(false, err)
+				} else {
+					r.updateRemoteClusterStatus(true, nil)
+				}
+			}
+		}
+	}()
+
+	r.stopFunc = stopFunc
+	return stopFunc, nil
+}
+
+func (r *remoteCluster) Stop() error {
+	if r.stopFunc == nil {
+		return nil
+	}
+
+	r.stopFunc()
+	return nil
+}
+
+func (r *remoteCluster) IsConnected() bool {
+	return r.connected
+}

--- a/multicluster/controllers/multicluster/internal/remote_cluster_manager.go
+++ b/multicluster/controllers/multicluster/internal/remote_cluster_manager.go
@@ -1,0 +1,156 @@
+package internal
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+)
+
+type clusterEvent struct {
+	isAdd         bool
+	remoteCluster RemoteCluster
+}
+
+type RemoteClusterManager interface {
+	// Start RemoteClusterManager on an event loop in a go routine
+	Start() error
+	// Stop RemoteClusterManager
+	Stop() error
+	// AddRemoteCluster adds a remote cluster to RemoteClusterManager.
+	AddRemoteCluster(remoteCluster RemoteCluster)
+	// RemoveRemoteCLuster removes a remote cluster from RemoteClusterManager.
+	RemoveRemoteCluster(remoteCluster RemoteCluster)
+	// GetRemteClusters returns all remote clusters
+	GetRemoteClusters() map[common.ClusterID]RemoteCluster
+	// GetElectedLeaderClusterID returns the leader remote cluster or INVALID_CLUSTER_ID if none elected
+	GetElectedLeaderClusterID() common.ClusterID
+	// GetLocalClusterID returns local cluster ID
+	GetLocalClusterID() common.ClusterID
+}
+
+// The manager manages all leaders defined in the cluster set and manages common area access into them.
+// It also interfaces with leader election to know the elected-leader from which resources
+// must be monitored.
+type remoteClusterManager struct {
+	log logr.Logger
+
+	clusterSetID common.ClusterSetID
+
+	// map of all remote clusters to which we have access to their common area
+	remoteClusters map[common.ClusterID]RemoteCluster
+
+	// an elected leader in which certain operations need to be performed
+	electedLeaderCluster RemoteCluster
+
+	// set to true if we require leader election
+	needElection bool
+
+	// Local cluster ID
+	clusterID common.ClusterID
+
+	eventChan chan clusterEvent
+
+	// Copy of remoteClusters for access from cluster set reconciler to avoid locking on remoteClusters
+	clusterSyncMap sync.Map
+
+	stopFunc context.CancelFunc
+}
+
+func NewRemoteClusterManager(clusterSetID common.ClusterSetID, log logr.Logger, clusterID common.ClusterID) RemoteClusterManager {
+	return &remoteClusterManager{
+		clusterSetID:   clusterSetID,
+		clusterID:      clusterID,
+		log:            log,
+		eventChan:      make(chan clusterEvent),
+		remoteClusters: make(map[common.ClusterID]RemoteCluster),
+	}
+}
+
+/**
+ * RemoteClusterManager implementation
+ */
+
+func (r *remoteClusterManager) Start() error {
+	r.log.Info("Starting remote cluster manager for", "clusterset", r.clusterSetID)
+	stopCtx, stopFunc := context.WithCancel(context.Background())
+	r.StartLeaderElection()
+
+	go func() {
+		for {
+			select {
+			case <-stopCtx.Done():
+				// we are done
+				return
+			case event := <-r.eventChan:
+				// process event
+				clusterID := event.remoteCluster.GetClusterID()
+
+				if event.isAdd {
+					if _, ok := r.remoteClusters[clusterID]; ok {
+						r.log.Error(nil, "Cannot add remote cluster already in manager", "clusterID", clusterID)
+					} else {
+						event.remoteCluster.Start()
+						r.remoteClusters[clusterID] = event.remoteCluster
+					}
+				} else {
+					if rc, ok := r.remoteClusters[clusterID]; !ok {
+						r.log.Error(nil, "Cannot remove remote cluster not in manager", "clusterID", clusterID)
+					} else {
+						rc.Stop()
+					}
+					delete(r.remoteClusters, clusterID)
+				}
+			}
+		}
+	}()
+
+	r.stopFunc = stopFunc
+	return nil
+}
+
+func (r *remoteClusterManager) Stop() error {
+	if r.stopFunc != nil {
+		r.stopFunc()
+	}
+	return nil
+}
+
+func (r *remoteClusterManager) AddRemoteCluster(remoteCluster RemoteCluster) {
+	r.clusterSyncMap.Store(remoteCluster.GetClusterID(), remoteCluster)
+	r.eventChan <- clusterEvent{
+		isAdd:         true,
+		remoteCluster: remoteCluster,
+	}
+}
+
+func (r *remoteClusterManager) RemoveRemoteCluster(remoteCluster RemoteCluster) {
+	r.clusterSyncMap.Store(remoteCluster.GetClusterID(), remoteCluster)
+	r.eventChan <- clusterEvent{
+		isAdd:         false,
+		remoteCluster: remoteCluster,
+	}
+}
+
+func (r *remoteClusterManager) GetRemoteClusters() map[common.ClusterID]RemoteCluster {
+	clusters := make(map[common.ClusterID]RemoteCluster)
+	r.clusterSyncMap.Range(func(k, v interface{}) bool {
+		id := k.(common.ClusterID)
+		clusters[id] = v.(RemoteCluster)
+		return true
+	})
+	return clusters
+}
+
+func (r *remoteClusterManager) GetElectedLeaderClusterID() common.ClusterID {
+	if r.electedLeaderCluster != nil {
+		return r.electedLeaderCluster.GetClusterID()
+	}
+	return common.INVALID_CLUSTER_ID
+}
+
+func (r *remoteClusterManager) GetLocalClusterID() common.ClusterID {
+	return r.clusterID
+}


### PR DESCRIPTION
Implement the reconciller for the ClusterSet CRD. The ClusterSet CRD depends on the ClusterClaim CRD, although
the two can be configured in any order, the ClusterSet CRD will perform validations to make sure it will be processed only after the appropriate ClusterClaim CRDs are present.

Leader ClusterSet controller - Currently creates access to the local namespace using the Common Area abstraction

```
 Leader ClusterSet Controller
            |
 InboundLeaderClusterManager
            |
       Common Area
  (access to local cluster
   namespace)
```

Member ClusterSet controller - read the leader list from spec and mantain a connection to each of them using the
controller-runtime library. This connection is abstracted as the common area of the leader cluster namespace for the
member to write to and listen for monitor updates

```
 Member ClusterSet Controller
            |
   Remote Cluster Manager
            | 1:N
      Remote Cluster
            |
      Common Area
  (access to remote cluster
   namespace)
```