### PR TITLE
fix common area bug

### DIFF
--- a/multicluster/controllers/multicluster/internal/remote_cluster.go
+++ b/multicluster/controllers/multicluster/internal/remote_cluster.go
@@ -18,7 +18,6 @@ import (
 
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	"antrea.io/antrea/multicluster/controllers/multicluster/common"
-
 )
 
 var (
@@ -80,8 +79,8 @@ type remoteCluster struct {
  * A remote cluster is a leader in the ClusterSet Spec. This creates a remoteCluster instance which will
  * use the secret and access credentials for the leader to connect to its common area.
  */
-func  NewRemoteCluster(clusterID common.ClusterID, clusterSetID common.ClusterSetID, url string, secretName string,
-	scheme *runtime.Scheme, log logr.Logger, remoteClusterManager RemoteClusterManager, clusterSetNamespace string,
+func NewRemoteCluster(clusterID common.ClusterID, clusterSetID common.ClusterSetID, url string, secretName string,
+	scheme *runtime.Scheme, log logr.Logger, remoteClusterManager *RemoteClusterManager, clusterSetNamespace string,
 	configNamespace string) (common.CommonArea, error) {
 	log = log.WithName("remote-cluster-" + string(clusterID))
 	log.Info("Create remote cluster for", "cluster", clusterID)
@@ -128,10 +127,10 @@ func  NewRemoteCluster(clusterID common.ClusterID, clusterSetID common.ClusterSe
 		scheme:               scheme,
 		Namespace:            clusterSetNamespace,
 		connected:            false,
-		remoteClusterManager: remoteClusterManager,
+		remoteClusterManager: *remoteClusterManager,
 	}
 
-	remoteClusterManager.AddRemoteCluster(cluster)
+	(*remoteClusterManager).AddRemoteCluster(cluster)
 
 	return cluster, nil
 }


### PR DESCRIPTION
1. fix the issue that remote cluster is actually added to a local variable instead of  `r.RemoteClusterManager`
2. fix the issue that RemoteClusterManager is set to nil immediately after it's start
Signed-off-by: Lan Luo <luola@vmware.com>