### PR TITLE
MCS Fixes for demo

### DIFF
--- a/multicluster/apis/multicluster/v1alpha1/clusterclaim_types.go
+++ b/multicluster/apis/multicluster/v1alpha1/clusterclaim_types.go
@@ -36,10 +36,8 @@ const (
 type ClusterClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// TODO: Remove the name as it is already part of ObjectMeta and its
-	// confusing to have two names
 	// Name of the ClusterClaim.
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty"` // TODO: Remove the name as it is already part of ObjectMeta and its confusing to have two names
 	// Value of the ClusterClaim.
 	Value string `json:"value,omitempty"`
 }

--- a/multicluster/build/yamls/antrea-multicluster-leader-only.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-only.yml
@@ -3,20 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: clusterclaims.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ClusterClaim
@@ -59,20 +50,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: clustersets.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ClusterSet
@@ -224,20 +206,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: memberclusterannounces.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: MemberClusterAnnounce
@@ -332,20 +305,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: resourceexports.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ResourceExport
@@ -769,20 +733,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: resourceimports.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ResourceImport
@@ -1837,19 +1792,12 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
         - mountPath: /controller_manager_config.yaml
           name: manager-config
           subPath: controller_manager_config.yaml
       serviceAccountName: antrea-multicluster-controller
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-cert
       - configMap:
           name: antrea-multicluster-manager-config
         name: manager-config

--- a/multicluster/build/yamls/antrea-multicluster-member-only.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member-only.yml
@@ -3,20 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: clusterclaims.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ClusterClaim
@@ -59,20 +50,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: clustersets.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ClusterSet
@@ -224,20 +206,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: memberclusterannounces.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: MemberClusterAnnounce
@@ -332,20 +305,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: resourceexports.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ResourceExport
@@ -769,20 +733,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: resourceimports.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ResourceImport
@@ -1837,19 +1792,12 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
         - mountPath: /controller_manager_config.yaml
           name: manager-config
           subPath: controller_manager_config.yaml
       serviceAccountName: antrea-multicluster-controller
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-cert
       - configMap:
           name: antrea-multicluster-manager-config
         name: manager-config

--- a/multicluster/build/yamls/antrea-multicluster.yml
+++ b/multicluster/build/yamls/antrea-multicluster.yml
@@ -3,20 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: clusterclaims.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ClusterClaim
@@ -59,20 +50,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: clustersets.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ClusterSet
@@ -224,20 +206,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: memberclusterannounces.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: MemberClusterAnnounce
@@ -332,20 +305,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: resourceexports.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ResourceExport
@@ -769,20 +733,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   labels:
     app: antrea
   name: resourceimports.multicluster.crd.antrea.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: antrea-multicluster-webhook-service
-          namespace: kube-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: multicluster.crd.antrea.io
   names:
     kind: ResourceImport
@@ -1837,19 +1792,12 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
         - mountPath: /controller_manager_config.yaml
           name: manager-config
           subPath: controller_manager_config.yaml
       serviceAccountName: antrea-multicluster-controller
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-cert
       - configMap:
           name: antrea-multicluster-manager-config
         name: manager-config

--- a/multicluster/config/crd/kustomization.yaml
+++ b/multicluster/config/crd/kustomization.yaml
@@ -15,14 +15,15 @@ resources:
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# Dont need conversion webhook since we only have one version right now
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_clusterclaims.yaml
-- patches/webhook_in_memberclusterannounces.yaml
-- patches/webhook_in_clustersets.yaml
+# patches/webhook_in_clusterclaims.yaml
+# patches/webhook_in_memberclusterannounces.yaml
+# patches/webhook_in_clustersets.yaml
 #- patches/webhook_in_resourceexportfilters.yaml
 #- patches/webhook_in_resourceimportfilters.yaml
-- patches/webhook_in_resourceexports.yaml
-- patches/webhook_in_resourceimports.yaml
+# patches/webhook_in_resourceexports.yaml
+# patches/webhook_in_resourceimports.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/multicluster/config/default/manager_webhook_patch.yaml
+++ b/multicluster/config/default/manager_webhook_patch.yaml
@@ -12,12 +12,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-cert

--- a/multicluster/controllers/multicluster/internal/remote_cluster.go
+++ b/multicluster/controllers/multicluster/internal/remote_cluster.go
@@ -107,6 +107,7 @@ func NewRemoteCluster(clusterID common.ClusterID, clusterSetID common.ClusterSet
 		Scheme:             scheme,
 		MetricsBindAddress: "0",
 		Logger:             log.WithName("controller-runtime"),
+		Namespace:          clusterSetNamespace,
 	})
 	if err != nil {
 		log.V(1).Error(err, "unable to create new manager")


### PR DESCRIPTION
1. Remove the cert manager mount from mcs controller so it starts up
   without mount errors
2. Make controller-runtime reconciler registration per namespace
   instead of cluster scope
3. Also dont hard-code the webhook names and generate based on the
   namespace the leader is running
4. remove conversion webhooks from crd definition since there is
   only one version for now